### PR TITLE
hook: tests-writer-guard fail-closed + 죽은 패턴 제거 (이슈 #4 #1·#2)

### DIFF
--- a/.claude/hooks/tests-writer-guard.sh
+++ b/.claude/hooks/tests-writer-guard.sh
@@ -6,76 +6,149 @@
 # unit-test-writer) 의 호출은 stdin JSON 의 `agent_id` 필드 존재 여부로
 # 식별해 그대로 통과시킨다.
 #
-# 근거: CLAUDE.md "테스트 작성 정책" — tests/ 수정은 unit-test-writer 경유.
+# 정책: fail-closed. payload 파싱 자체에 실패하거나 의심스러운 입력이면
+# 통과가 아니라 차단이 기본이다. "알 수 없으면 통과" 는 규율 우회의 경로.
+#
+# 경로 매칭은 symlink 해소 후(`pwd -P`) `PROJECT_ROOT` prefix 로 판정해
+# macOS `/var` ↔ `/private/var` 같은 표기 차이에 속지 않는다.
+#
+# 근거: CLAUDE.md "테스트 작성 정책", 이슈 #4.
 # hook 스펙: https://code.claude.com/docs/en/hooks.md (PreToolUse)
 
 set -euo pipefail
 
 PAYLOAD="$(cat)"
 
-# agent_id 가 있으면 서브에이전트 호출. 그대로 통과.
-AGENT_ID="$(
+# ---------------------------------------------------------------------------
+# 1) payload 파싱 — 파싱 실패는 fail-closed.
+#    필드가 아예 없는 것(정상 케이스) 과 JSON 자체가 깨진 것(비정상)을 구분.
+#    성공 시 3 줄을 출력: agent_id, tool_name, file_path (각 줄은 빈 문자열 가능).
+# ---------------------------------------------------------------------------
+
+if ! FIELDS="$(
   printf '%s' "$PAYLOAD" | python3 -c '
 import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    sys.exit(1)
 try:
-    d = json.loads(sys.stdin.read())
-    print(d.get("agent_id") or "")
+    d = json.loads(raw)
 except Exception:
-    print("")
-' 2>/dev/null || echo ""
-)"
+    sys.exit(1)
+if not isinstance(d, dict):
+    sys.exit(1)
+ti = d.get("tool_input") or {}
+if not isinstance(ti, dict):
+    ti = {}
+agent_id = d.get("agent_id") or ""
+tool_name = d.get("tool_name") or ""
+file_path = ti.get("file_path") or ti.get("notebook_path") or ""
+print(agent_id)
+print(tool_name)
+print(file_path)
+'
+)"; then
+  {
+    echo "[tests-writer-guard] PreToolUse payload 파싱 실패 — 안전상 차단."
+    echo ""
+    echo "JSON 구조가 아니거나 최상위가 객체가 아닙니다. hook 이 의도치 않게"
+    echo "우회될 위험이 있어 fail-closed 정책으로 tool 실행을 막습니다."
+    echo ""
+    echo "조치: payload 생성 지점(상위 셸 파이프·테스트 스크립트 등)을 확인하거나,"
+    echo "      의도한 변경이라면 tests/ 수정은 unit-test-writer 서브에이전트를"
+    echo "      경유하세요."
+  } >&2
+  exit 2
+fi
+
+# 각 read 뒤 `|| true` 로 EOF 에서의 exit 1 이 set -e 를 트리거하지 않도록 함.
+# (macOS 의 bash 3.2 는 mapfile 을 지원하지 않아 read 기반으로 구현)
+AGENT_ID=""
+TOOL_NAME=""
+FILE_PATH=""
+{
+  IFS= read -r AGENT_ID || true
+  IFS= read -r TOOL_NAME || true
+  IFS= read -r FILE_PATH || true
+} <<< "$FIELDS"
+
+# ---------------------------------------------------------------------------
+# 2) 서브에이전트 호출이면 통과.
+# ---------------------------------------------------------------------------
 
 if [ -n "$AGENT_ID" ]; then
   exit 0
 fi
 
-TOOL_NAME="$(
-  printf '%s' "$PAYLOAD" | python3 -c '
-import json, sys
-try:
-    print(json.loads(sys.stdin.read()).get("tool_name", ""))
-except Exception:
-    print("")
-' 2>/dev/null || echo ""
-)"
+# ---------------------------------------------------------------------------
+# 3) 대상 도구가 아니면 통과.
+# ---------------------------------------------------------------------------
 
 case "$TOOL_NAME" in
   Write|Edit|NotebookEdit) : ;;
   *) exit 0 ;;
 esac
 
-FILE_PATH="$(
-  printf '%s' "$PAYLOAD" | python3 -c '
-import json, sys
-try:
-    ti = json.loads(sys.stdin.read()).get("tool_input", {}) or {}
-    print(ti.get("file_path", "") or ti.get("notebook_path", ""))
-except Exception:
-    print("")
-' 2>/dev/null || echo ""
-)"
+# ---------------------------------------------------------------------------
+# 4) file_path 가 없으면 판정 근거 부재 — 가드 대상 아님(통과).
+#    (Write/Edit 는 파일 경로가 필수라 빈 값은 Claude Code 가 애초에 거부)
+# ---------------------------------------------------------------------------
 
 [ -z "$FILE_PATH" ] && exit 0
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-[ -z "$PROJECT_ROOT" ] && exit 0
+# ---------------------------------------------------------------------------
+# 5) PROJECT_ROOT 확보 + symlink 해소.
+# ---------------------------------------------------------------------------
 
-# stock-agent 밖이면 간섭하지 않는다.
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$PROJECT_ROOT" ] && exit 0  # git 저장소 밖 — stock-agent 와 무관.
+
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P || echo "$PROJECT_ROOT")"
+
 case "$PROJECT_ROOT" in
   */stock-agent) : ;;
-  *) exit 0 ;;
+  *) exit 0 ;;  # 다른 프로젝트 — 간섭 안 함.
 esac
 
-# 상대경로로 정규화.
+# ---------------------------------------------------------------------------
+# 6) FILE_PATH 정규화.
+#    절대경로면 dirname 을 pwd -P 로 symlink 해소해 PROJECT_ROOT 와 동일
+#    표기로 맞춘다. 신규 파일 생성 케이스에서 dirname 이 아직 없으면 원문
+#    유지 (이후 prefix 매칭 실패 시 간섭 안 함으로 귀결).
+# ---------------------------------------------------------------------------
+
 case "$FILE_PATH" in
-  "$PROJECT_ROOT"/*) REL="${FILE_PATH#$PROJECT_ROOT/}" ;;
-  /*) exit 0 ;;  # stock-agent 외부 절대경로는 간섭 대상 아님
-  *) REL="$FILE_PATH" ;;
+  /*)
+    _dir="$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P || true)"
+    if [ -n "$_dir" ]; then
+      FILE_PATH_NORM="$_dir/$(basename "$FILE_PATH")"
+    else
+      FILE_PATH_NORM="$FILE_PATH"
+    fi
+    ;;
+  *)
+    FILE_PATH_NORM="$FILE_PATH"
+    ;;
 esac
 
-# tests/*.py 또는 tests/**/*.py 만 대상.
+# ---------------------------------------------------------------------------
+# 7) PROJECT_ROOT prefix 로 상대경로 산출.
+# ---------------------------------------------------------------------------
+
+case "$FILE_PATH_NORM" in
+  "$PROJECT_ROOT"/*) REL="${FILE_PATH_NORM#"$PROJECT_ROOT"/}" ;;
+  /*) exit 0 ;;             # stock-agent 밖 절대경로 — 간섭 안 함.
+  *) REL="$FILE_PATH_NORM" ;;  # 상대경로 그대로.
+esac
+
+# ---------------------------------------------------------------------------
+# 8) tests/*.py 매칭 — bash case 의 * 는 / 를 포함해 전부 매칭하므로
+#    단일 패턴으로 tests/test_x.py, tests/sub/test_y.py, tests/__init__.py,
+#    tests/conftest.py 모두 잡힌다.
+# ---------------------------------------------------------------------------
+
 case "$REL" in
-  tests/*.py|tests/**/*.py) : ;;
+  tests/*.py) : ;;
   *) exit 0 ;;
 esac
 


### PR DESCRIPTION
## Summary
PR #3 리뷰에서 이슈 #4 로 남겨진 Important 2건 수정 — 테스트 쓰기 가드 hook 의 신뢰성 보강.

- **이슈 #4 #1** (죽은 패턴): `case` 의 `tests/**/*.py` 분지는 bash glob 특성상 `tests/*.py` 로 전부 매칭되어 도달 불가능. 단일 패턴으로 축약.
- **이슈 #4 #2** (fail-open):
  - JSON 파싱 실패 / 최상위가 dict 가 아닌 입력 → `exit 2` + stderr 안내로 fail-closed.
  - `PROJECT_ROOT` · `FILE_PATH` 를 `pwd -P` 로 symlink 해소 후 prefix 비교 → macOS `/var` ↔ `/private/var` 표기 엇갈림에 속지 않음.

## 왜
하네스의 핵심 레일이 silent `exit 0` 로 여러 곳에서 우회 가능했음. "알 수 없으면 통과" 는 규율을 코드로 잠근다는 의도에 어긋나므로 fail-closed 로 전환. Phase 2 (백테스트·리스크) 진입 전에 이 가드의 신뢰성 확보.

## 변경 범위
- 수정: `.claude/hooks/tests-writer-guard.sh` (단일 파일, +109 / -36 라인)
- 신규 없음, 문서 동기화 없음 (기술 스택·디렉토리·명령 변경 없음)

## Test plan
스모크 13 시나리오 로컬 검증:

| 기대 차단 (exit 2) | 기대 통과 (exit 0) |
|---|---|
| main Write `tests/test_x.py` | main Write `src/stock_agent/foo.py` |
| main Write `tests/sub/test_y.py` | subagent(`agent_id` 주입) + tests/ Write |
| main Write `tests/__init__.py` | `tool_name=Bash` |
| main Edit `tests/` | 프로젝트 외부 절대경로 |
| main Write 상대경로 `tests/test_rel.py` | `tests/README.md` (non-py) |
| 비-JSON stdin | |
| 빈 stdin | |
| 최상위 JSON 배열 | |

- [x] 스모크 13 시나리오 모두 기대치 일치
- [x] `uv run pytest -q` — 43/43 green, 1.22s
- [x] `uv run ruff check src tests` — clean
- [x] `uv run black --check src tests` — 차이 없음
- [ ] 사용자 환경에서 실제 Claude Code 세션으로 한 번 더 확인 (선택)

## 호환성
macOS 기본 bash 3.2 와의 호환을 위해 `mapfile` 대신 `read + || true` 조합 사용. `set -e` 아래 EOF 도달 시 조기 종료를 방지.

## 이슈 #4 남은 항목 (이 PR 에서 제외)
- #3: `rate_limiter._purge` 의 `>=` 경계 테스트 잠금
- #4: `_place_order` 네트워크 실패 시에도 slot 소비 정책 테스트

코드가 바뀌지 않는 안정 모듈이라 Phase 2 진입 전 어느 세션에서 묶어 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)