### PR TITLE
ci: pyright 게이트에 tests/ 범위 편입 (baseline 23→0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,8 @@ jobs:
       - name: Format check (black)
         run: uv run black --check src scripts tests
 
-      - name: Type check (pyright, src/scripts only)
-        # tests/ 는 MagicMock spec 추론 등 목킹 특유의 false positive 가 있어
-        # 범위 밖 — 후속 PR 에서 baseline 캡처 후 점진 도입.
-        run: uv run pyright src scripts
+      - name: Type check (pyright)
+        run: uv run pyright src scripts tests
 
       - name: Tests (pytest)
         run: uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,8 @@ addopts = "-q"
 [tool.pyright]
 # 에디터 LSP 와 CI 게이트 공통 설정.
 #
-# CI 는 `uv run pyright src scripts` 만 실행 — tests 는 범위 밖 (MagicMock spec 추론·
-# Decimal/int 자동 변환 등 목킹 특유의 false positive 가 누적되어 있어 점진 정리를
-# 후속 PR 로 이관). src/scripts 는 현재 pyright clean (경고 0) 상태라 신규 드리프트
-# 를 즉시 차단한다. tests 범위 확장은 후속 PR 에서 baseline 캡처 후 진행.
+# CI 는 `uv run pyright src scripts tests` 실행 — src/scripts/tests 모두 pyright
+# clean (경고 0) 상태로 신규 드리프트를 즉시 차단한다.
 venvPath = "."
 venv = ".venv"
 include = ["src", "scripts", "tests"]

--- a/tests/test_backtest_cli.py
+++ b/tests/test_backtest_cli.py
@@ -70,18 +70,25 @@ _DATE_START = date(2023, 1, 1)
 _DATE_END = date(2025, 12, 31)
 
 
-def _make_metrics(**overrides) -> BacktestMetrics:
-    defaults = dict(
-        total_return_pct=Decimal("0.08"),
-        max_drawdown_pct=Decimal("-0.12"),
-        sharpe_ratio=Decimal("1.2"),
-        win_rate=Decimal("0.55"),
-        avg_pnl_ratio=Decimal("1.3"),
-        trades_per_day=Decimal("1.2"),
-        net_pnl_krw=80_000,
+def _make_metrics(
+    *,
+    total_return_pct: Decimal = Decimal("0.08"),
+    max_drawdown_pct: Decimal = Decimal("-0.12"),
+    sharpe_ratio: Decimal = Decimal("1.2"),
+    win_rate: Decimal = Decimal("0.55"),
+    avg_pnl_ratio: Decimal = Decimal("1.3"),
+    trades_per_day: Decimal = Decimal("1.2"),
+    net_pnl_krw: int = 80_000,
+) -> BacktestMetrics:
+    return BacktestMetrics(
+        total_return_pct=total_return_pct,
+        max_drawdown_pct=max_drawdown_pct,
+        sharpe_ratio=sharpe_ratio,
+        win_rate=win_rate,
+        avg_pnl_ratio=avg_pnl_ratio,
+        trades_per_day=trades_per_day,
+        net_pnl_krw=net_pnl_krw,
     )
-    defaults.update(overrides)
-    return BacktestMetrics(**defaults)
 
 
 def _make_trade(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -13,7 +13,7 @@ import dataclasses
 from collections.abc import Callable
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -91,7 +91,11 @@ def _bar(
     )
 
 
-def _ticket(symbol: str = _SYMBOL_A, side: str = "buy", n: int = 1) -> OrderTicket:
+def _ticket(
+    symbol: str = _SYMBOL_A,
+    side: Literal["buy", "sell"] = "buy",
+    n: int = 1,
+) -> OrderTicket:
     """OrderTicket 생성 헬퍼."""
     return OrderTicket(
         order_number=f"ORD-{n:04d}",
@@ -252,7 +256,7 @@ def fake_bar_source() -> FakeBarSource:
 def _make_executor(
     strategy: ORBStrategy,
     risk_manager: RiskManager,
-    fake_order_submitter: FakeOrderSubmitter,
+    fake_order_submitter: OrderSubmitter,
     fake_balance_provider: FakeBalanceProvider,
     fake_bar_source: FakeBarSource,
     *,
@@ -358,7 +362,7 @@ class TestExecutorConfig:
             "sell_tax_rate_음수",
         ],
     )
-    def test_비율_음수_RuntimeError(self, field_name: str, bad_value: Decimal) -> None:
+    def test_비율_음수_RuntimeError(self, field_name: str, bad_value: Any) -> None:
         with pytest.raises(RuntimeError):
             ExecutorConfig(**{field_name: bad_value})
 

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -50,11 +51,13 @@ def _make_ohlcv_df(
         "종가": [r[4] for r in rows],
         "거래량": [r[5] for r in rows],
     }
-    return pd.DataFrame(data, index=index)
+    # pandas stubs: Axes|None 만 허용 — list[Timestamp]/list[str] 가 좁혀지지 않는 한계
+    return pd.DataFrame(data, index=cast(Any, index))
 
 
 def _empty_ohlcv_df() -> pd.DataFrame:
-    return pd.DataFrame(columns=["시가", "고가", "저가", "종가", "거래량"])
+    # pandas stubs: Axes|None 만 허용 — list[Timestamp]/list[str] 가 좁혀지지 않는 한계
+    return pd.DataFrame(columns=cast(Any, ["시가", "고가", "저가", "종가", "거래량"]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -479,7 +479,7 @@ def test_install_jobs_cron_시각_검증(
     _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
 
     call_kwargs = scheduler.add_job.call_args_list[job_index]
-    trigger: CronTrigger = call_kwargs.kwargs.get("trigger") or (
+    trigger = call_kwargs.kwargs.get("trigger") or (
         call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
     )
     assert isinstance(trigger, CronTrigger)
@@ -504,7 +504,7 @@ def test_install_jobs_step_hour_range_9_14() -> None:
 
     # on_step 은 두 번째(index=1) add_job
     step_call = scheduler.add_job.call_args_list[1]
-    trigger: CronTrigger = step_call.kwargs.get("trigger") or (
+    trigger = step_call.kwargs.get("trigger") or (
         step_call.args[1] if len(step_call.args) > 1 else None
     )
     assert isinstance(trigger, CronTrigger)
@@ -523,7 +523,7 @@ def test_install_jobs_모두_mon_fri_Asia_Seoul() -> None:
     _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
 
     for idx, c in enumerate(scheduler.add_job.call_args_list):
-        trigger: CronTrigger = c.kwargs.get("trigger") or (c.args[1] if len(c.args) > 1 else None)
+        trigger = c.kwargs.get("trigger") or (c.args[1] if len(c.args) > 1 else None)
         trigger_msg = f"job[{idx}] trigger 는 CronTrigger 여야 한다"
         assert isinstance(trigger, CronTrigger), trigger_msg
         tz_msg = f"job[{idx}] timezone 이 Asia/Seoul 이어야 한다"
@@ -886,10 +886,6 @@ def test_graceful_shutdown_sig_dfl_교체(mocker: Any) -> None:
     _graceful_shutdown(runtime, SIGTERM, None)
 
     # signal.signal 이 SIG_DFL 로 2회 교체되어야 함
-    [
-        call(_signal.SIGINT, _signal.SIG_DFL),
-        call(_signal.SIGTERM, _signal.SIG_DFL),
-    ]
     mock_signal.assert_any_call(_signal.SIGINT, _signal.SIG_DFL)
     mock_signal.assert_any_call(_signal.SIGTERM, _signal.SIG_DFL)
     # scheduler.shutdown 보다 먼저 호출됐는지 (call_order): signal.signal 2회가

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -11,8 +11,8 @@ stock_agent.monitor 패키지와 stock_agent.execution 의 EntryEvent/ExitEvent 
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Callable
 from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -59,8 +59,11 @@ def _make_bot_mock() -> MagicMock:
     return bot
 
 
-def _make_bot_factory(bot: MagicMock) -> Callable[[str], MagicMock]:
-    """주어진 bot 인스턴스를 반환하는 단순 팩토리."""
+def _make_bot_factory(bot: MagicMock) -> MagicMock:
+    """주어진 bot 인스턴스를 반환하는 MagicMock 팩토리.
+
+    Callable 로 호출 가능하면서 assert_called_once/call_args 접근 가능.
+    """
     return MagicMock(return_value=bot)
 
 
@@ -90,11 +93,11 @@ def _make_entry_event(
     *,
     symbol: str = _SYMBOL,
     qty: int = 10,
-    fill_price: int = 50_000,
-    ref_price: int = 49_500,
+    fill_price: Decimal = Decimal("50000"),
+    ref_price: Decimal = Decimal("49500"),
 ) -> EntryEvent:
-    """EntryEvent 더블 — execution 구현 후 실 타입으로 교체."""
-    return EntryEvent(  # type: ignore[call-arg]
+    """EntryEvent 더블."""
+    return EntryEvent(
         symbol=symbol,
         qty=qty,
         fill_price=fill_price,
@@ -107,12 +110,12 @@ def _make_exit_event(
     *,
     symbol: str = _SYMBOL,
     qty: int = 10,
-    fill_price: int = 51_500,
+    fill_price: Decimal = Decimal("51500"),
     reason: ExitReason = "take_profit",
     net_pnl_krw: int = 14_000,
 ) -> ExitEvent:
-    """ExitEvent 더블 — execution 구현 후 실 타입으로 교체."""
-    return ExitEvent(  # type: ignore[call-arg]
+    """ExitEvent 더블."""
+    return ExitEvent(
         symbol=symbol,
         qty=qty,
         fill_price=fill_price,
@@ -350,14 +353,14 @@ class TestNotifyEntry:
     def test_text_contains_fill_price(self) -> None:
         bot = _make_bot_mock()
         n = _make_notifier(bot=bot)
-        n.notify_entry(_make_entry_event(fill_price=52_000))
+        n.notify_entry(_make_entry_event(fill_price=Decimal("52000")))
         _, kwargs = bot.send_message.call_args
         assert "52000" in kwargs["text"] or "52,000" in kwargs["text"]
 
     def test_text_contains_ref_price(self) -> None:
         bot = _make_bot_mock()
         n = _make_notifier(bot=bot)
-        n.notify_entry(_make_entry_event(ref_price=51_800))
+        n.notify_entry(_make_entry_event(ref_price=Decimal("51800")))
         _, kwargs = bot.send_message.call_args
         assert "51800" in kwargs["text"] or "51,800" in kwargs["text"]
 


### PR DESCRIPTION
## Summary

- Issue #19 해소: `tests/` 의 pyright baseline 23 errors + 1 warning 을 0 으로 정리하고 CI 게이트 (`uv run pyright`) 경로를 `src scripts` → `src scripts tests` 로 확장.
- 모든 수정은 테스트 동작 불변 — 헬퍼 시그니처 좁힘·명시 파라미터 전개·`cast(Any, ...)` 로 알려진 스텁 한계 우회. 실제 타입 버그 은폐 목적의 규칙 off 는 도입 안 함.
- `src/stock_agent/` 수정 0건 (Issue #19 범위 외).

## 변경 요약

| 파일 | 처리 |
|---|---|
| `tests/test_backtest_cli.py` | `_make_metrics` `**overrides` 패턴 → keyword-only 명시 파라미터 (dict value union 추론 제거, 7건) |
| `tests/test_executor.py` | `_ticket.side: Literal["buy","sell"]`, `bad_value: Decimal` → `Any`, `_make_executor.fake_order_submitter: OrderSubmitter` Protocol (6건) |
| `tests/test_historical.py` | `cast(Any, ...)` 로 pandas stubs `Axes\|None` 제약 우회 (2건, 알려진 한계) |
| `tests/test_main.py` | `CronTrigger` 로컬 타입 선언 제거 → 기존 `isinstance` narrowing 에 위임, unused list literal 삭제 (3건 + 1 warning) |
| `tests/test_notifier.py` | `_make_bot_factory` 반환 타입 `MagicMock`, `fill_price`/`ref_price` 기본값 `Decimal`, 불필요 `type: ignore[call-arg]` 제거 (5건) |
| `.github/workflows/ci.yml` | pyright step 경로 확장 + 스킵 이유 주석 제거 |
| `pyproject.toml` | `[tool.pyright]` 주석을 tests 편입 완료 문구로 단순화 |

## 합류 기준 (전부 통과)

- [x] `uv run pyright tests` → 0 errors, 0 warnings
- [x] `uv run pyright src scripts tests` → 0 errors, 0 warnings, 0 informations
- [x] `.github/workflows/ci.yml` pyright step 대상이 `src scripts tests` 로 확장
- [x] `[tool.pyright]` 완화 규칙 미도입 (실제 버그 은폐 금지 원칙 준수)
- [x] `uv run pytest` → 778 passed (회귀 0건)
- [x] `uv run ruff check` / `ruff format --check` / `black --check` 전부 green
- [x] `tests/` 수정은 `unit-test-writer` 서브에이전트 경유
- [x] `src/stock_agent/` 수정 0건

## Test plan

- [ ] GitHub Actions CI 의 `Type check (pyright)` step 이 `src scripts tests` 모두 커버하며 0 errors 로 통과
- [ ] CI `Tests (pytest)` step 778 passed
- [ ] 병합 후 에디터 LSP 가 동일 규칙으로 `tests/` 에서도 타입 경고 0건 유지

## 참고

- Issue: #19 (pyright CI 게이트에 tests/ 범위 점진 도입)
- 선행 PR: #18 (pyright CI 게이트 도입 + DTO 설계 체크리스트)
- baseline 수치: 이슈 본문은 25 errors 로 기록됐으나 PR 착수 시점(2026-04-21) 기준 실측치는 23 errors + 1 warning. 차이는 이슈 작성 이후 선행 PR 에서 일부 자동 해소된 것으로 추정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)