### PR TITLE
refactor(main): _safe_pct 로 pct 계산 타입 드리프트 방어 (#25)

### DIFF
--- a/src/stock_agent/main.py
+++ b/src/stock_agent/main.py
@@ -562,6 +562,27 @@ def _on_force_close(runtime: Runtime, clock: ClockFn) -> Callable[[], None]:
     return callback
 
 
+def _safe_pct(pnl: Any, starting: Any) -> float | None:
+    """pnl / starting × 100.0. 실패 시 None.
+
+    계산 실패와 텔레그램 발송 실패를 직교화한다. `RiskManager` 의
+    `starting_capital_krw`/`daily_realized_pnl_krw` 타입이 향후 Decimal 등으로
+    드리프트하더라도 `float()` 변환 + 명시 except 로 `TypeError`/`ValueError`/
+    `ArithmeticError` 를 흡수해 None 을 반환한다. 발송 경로(`notify_daily_summary`)
+    는 pct=None 을 "n/a" 로 출력하므로 계산 실패가 일일 요약 발송 자체를
+    막지 않는다 (Issue #25, PR #18 리뷰 후속 I3).
+    """
+    try:
+        if starting is None:
+            return None
+        s = float(starting)
+        if s <= 0:
+            return None
+        return (float(pnl) / s) * 100.0
+    except (TypeError, ValueError, ArithmeticError):
+        return None
+
+
 def _on_daily_report(runtime: Runtime, clock: ClockFn) -> Callable[[], None]:
     """15:30 — 당일 요약 로그 (`runtime.risk_manager` 공개 프로퍼티 사용).
 
@@ -581,9 +602,7 @@ def _on_daily_report(runtime: Runtime, clock: ClockFn) -> Callable[[], None]:
             entries = rm.entries_today
             active = len(rm.active_positions)
             starting = rm.starting_capital_krw
-            pct: float | None = (
-                (pnl / starting) * 100.0 if starting is not None and starting > 0 else None
-            )
+            pct = _safe_pct(pnl, starting)
             last_rec = runtime.executor.last_reconcile
             mismatch = last_rec.mismatch_symbols if last_rec is not None else ()
             logger.info(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1673,6 +1673,37 @@ def test_on_daily_report_realized_pnl_pct_None_when_starting_0_or_None(
     assert summary.realized_pnl_pct is None
 
 
+def test_on_daily_report_pct_decimal_타입_드리프트_내성(mocker: Any) -> None:
+    """I3 #25 — RiskManager pct 가 Decimal 로 드리프트해도
+    notify_daily_summary 가 호출되고 pct 는 정상 float 값이다.
+    """
+    from decimal import Decimal
+
+    fake_executor = MagicMock(spec=Executor)
+    fake_executor.is_halted = False
+    fake_executor.last_reconcile = None
+
+    fake_rm = MagicMock(spec=RiskManager)
+    fake_rm.daily_realized_pnl_krw = Decimal("-12345")
+    fake_rm.entries_today = 1
+    fake_rm.active_positions = ()
+    fake_rm.starting_capital_krw = Decimal("1000000")
+
+    fake_notifier = MagicMock(spec=Notifier)
+    mocker.patch("stock_agent.main.logger")
+
+    runtime = _make_runtime(executor=fake_executor, risk_manager=fake_rm, notifier=fake_notifier)
+    clock = lambda: _kst(15, 30)  # noqa: E731
+
+    cb = _on_daily_report(runtime, clock)
+    cb()
+
+    fake_notifier.notify_daily_summary.assert_called_once()
+    summary: DailySummary = fake_notifier.notify_daily_summary.call_args[0][0]
+    assert summary.realized_pnl_pct == pytest.approx(-1.2345, rel=1e-6)
+    fake_notifier.notify_error.assert_not_called()
+
+
 def test_on_daily_report_mismatch_symbols_from_last_reconcile(mocker: Any) -> None:
     """E4 — last_reconcile.mismatch_symbols=("A",) → DailySummary.mismatch_symbols==("A",).
     last_reconcile=None 이면 mismatch_symbols==().


### PR DESCRIPTION
## Summary

- `_on_daily_report` 의 `pct = (pnl / starting) * 100.0` 을 `_safe_pct(pnl, starting)` 순수 함수로 추출. `float()` 변환 + 명시 `except (TypeError, ValueError, ArithmeticError)` 로 `RiskManager` 필드 타입 드리프트(int → Decimal 등) 를 흡수해 `None` 을 반환.
- 계산 실패와 텔레그램 발송 실패를 직교화 — 계산 실패는 `pct=None` 으로 흡수되고 `notify_daily_summary` 발송은 항상 시도된다. 발송 실패만 상위 `except Exception` 이 잡는다.
- 회귀 테스트 1건(`test_on_daily_report_pct_decimal_타입_드리프트_내성`): `rm.{starting_capital_krw, daily_realized_pnl_krw}` 에 `Decimal` 주입 시 `notify_daily_summary` 1회 호출 + `realized_pnl_pct ≈ -1.2345` + `notify_error` 미호출 검증.

Closes #25

## Context

PR #18 (monitor/notifier) 코드 리뷰에서 defer 된 후속 정리 항목 I3 (Important 등급). Phase 3 모의투자 10영업일 운영 PASS 선언 재진입 전 해소 대상 — 일일 요약 누락은 운영자 판단 근거를 조용히 박탈하므로.

## 공개 계약 변경 없음

`Runtime`, `build_runtime`, 콜백 시그니처, `DailySummary` 필드 동일. `_safe_pct` 는 언더스코어 프라이빗.

## Test plan

- [x] `uv run pytest -q` — 전체 스위트 통과 (회귀 0건)
- [x] `uv run ruff check src tests scripts` — exit 0
- [x] `uv run black --check src tests scripts` — exit 0
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] RED 확인: 신규 테스트가 구현 전 `AssertionError: Expected 'notify_daily_summary' to have been called once. Called 0 times.` 로 실패 → `_safe_pct` 도입 후 PASS 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)