### PR TITLE
test(notifier): TelegramNotifier.__init__ bot_factory 예외 전파 회귀 방어 (#26)

### DIFF
--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -269,6 +269,24 @@ class TestTelegramNotifierInit:
         """정상 파라미터는 RuntimeError 없이 생성된다."""
         _make_notifier()  # 예외 없이 통과하면 pass
 
+    def test_bot_factory_raising_exception_propagates_from_init(self) -> None:
+        """bot_factory 가 예외를 던지면 __init__ 은 예외를 삼키지 말고 그대로 전파해야 한다.
+
+        근거: main.py._default_notifier_factory 의 `except Exception → NullNotifier` 폴백은
+        생성자가 예외를 전파한다는 하위 계약에 의존한다. 만약 __init__ 이 내부적으로
+        예외를 삼키고 self 를 반환하면, 잘못된 토큰으로 기동해도 NullNotifier 로 폴백되지
+        않고 silent 하게 "정상" 으로 오인된다 (이슈 #26).
+        """
+        boom = RuntimeError("bot factory failure")
+        factory = MagicMock(side_effect=boom)
+        with pytest.raises(RuntimeError) as exc_info:
+            TelegramNotifier(
+                bot_token=_TOKEN,
+                chat_id=_CHAT_ID,
+                bot_factory=factory,
+            )
+        assert exc_info.value is boom
+
 
 # ---------------------------------------------------------------------------
 # 4. bot_factory 주입 계약 — 생성자에서 1회 호출, 각 notify 에서 재사용


### PR DESCRIPTION
## Summary

- `TestTelegramNotifierInit` 에 `test_bot_factory_raising_exception_propagates_from_init` 1건 추가 — `TelegramNotifier.__init__` 이 주입된 `bot_factory` 의 예외를 삼키지 않고 그대로 전파함을 잠근다.
- `main.py._default_notifier_factory` 의 `except Exception → NullNotifier` 폴백이 하위 계약에 의존하므로, 누군가 실수로 `__init__` 에 `try/except` 를 감싸 silent 폴백을 반환하도록 바꾸면 즉시 이 테스트에서 감지된다.
- 관련 이슈: #26 (PR #18 리뷰 후속 I5).

## Scope

- `tests/test_notifier.py` 1파일, +18/-0. `src/` 수정 없음 (회귀 방어 전용).
- 실 네트워크·Telegram API 접촉 0 — `MagicMock(side_effect=RuntimeError(...))` 로 완전 격리.
- 기존 테스트 수정·삭제 없음, 순수 추가.

## Test plan

- [x] `uv run pytest -x tests/test_notifier.py::TestTelegramNotifierInit -q` → 5 passed
- [x] `uv run pytest -q` 전체 통과 (exit 0, skip 3건 기존 유지)
- [x] `uv run ruff check tests/test_notifier.py` → All checks passed
- [x] `uv run black --check tests/test_notifier.py` → unchanged
- [x] `uv run pyright src/stock_agent/monitor tests/test_notifier.py` → 오류 없음

## Out of scope

- `_default_notifier_factory` 의 parametrize 상위 레벨 검증은 이슈 #27 (I6) 에서 별도 처리.