### PR TITLE
test(main): _default_notifier_factory 예외 5종 parametrize 회귀 (#27)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1325,6 +1325,37 @@ def test_default_notifier_factory_TelegramNotifier_예외시_NullNotifier_폴백
     assert "NullNotifier" in warning_msg or "notifier_factory" in warning_msg
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RuntimeError("runtime"),
+        ValueError("invalid"),
+        ImportError("missing dep"),
+        OSError("network down"),
+        Exception("generic"),
+    ],
+    ids=["RuntimeError", "ValueError", "ImportError", "OSError", "Exception"],
+)
+def test_default_notifier_factory_예외_5종_모두_NullNotifier_폴백(
+    mocker: Any,
+    exc: Exception,
+) -> None:
+    """예외 5종 parametrize 회귀.
+
+    `except Exception` 을 좁히면 실패하도록 계약 잠금. 관련 이슈 #27.
+    """
+    fake_settings = _make_fake_settings_for_notifier()
+    mocker.patch("stock_agent.main.TelegramNotifier", side_effect=exc)
+    mock_logger = mocker.patch("stock_agent.main.logger")
+
+    result = _default_notifier_factory(fake_settings, dry_run=False)
+
+    assert isinstance(result, NullNotifier)
+    mock_logger.warning.assert_called_once()
+    warning_msg = str(mock_logger.warning.call_args)
+    assert "NullNotifier" in warning_msg or "notifier_factory" in warning_msg
+
+
 def test_default_notifier_factory_dry_run_True_가_TelegramNotifier에_전달됨(
     mocker: Any,
 ) -> None:


### PR DESCRIPTION
Closes #27.

## Summary
- `_default_notifier_factory` 의 `except Exception → NullNotifier` 폴백 계약을 5종 예외로 잠갔다.
- 기존 A2 테스트는 `RuntimeError` 1종만 검증 → `except` 절을 좁히는 회귀를 못 잡음. 실전 `TelegramNotifier.__init__` 은 `ValueError`/`ImportError`/`OSError` 등도 던질 수 있어 장중 부팅 재기동 시 치명적.
- parametrize 5종(`RuntimeError`/`ValueError`/`ImportError`/`OSError`/`Exception`) 모두 `NullNotifier` 반환 + `logger.warning` 1회를 검증.

## 변경 범위
- `tests/test_main.py` parametrize 테스트 1건 추가 (+31 lines).
- `src/` 무변경 — 계약 잠금 전용.
- 기존 A2 (`RuntimeError` 단독) 는 보존 — 최소 계약 예시로 남겨둠.
- 의존성 추가 없음.

## 검증
- `uv run pytest tests/test_main.py -q` → **108 passed** (기존 103 + 신규 5).
- `uv run ruff check tests/test_main.py` → green.
- `uv run black --check tests/test_main.py` → green.
- 프로젝트 규칙에 따라 `unit-test-writer` 서브에이전트 경유로 작성.

## Test plan
- [x] `uv run pytest "tests/test_main.py::test_default_notifier_factory_예외_5종_모두_NullNotifier_폴백" -q` → 5 passed
- [x] `uv run pytest tests/test_main.py -q` → 108 passed
- [x] `uv run ruff check tests/test_main.py` / `uv run black --check tests/test_main.py` green
- [ ] CI `Lint, format, test` green

## 관련 이슈
- #27 — 이 PR 이 해소.
- #26 (I5 — `TelegramNotifier.__init__` 생성자 예외 전파 계약) 과 짝. I5 는 하위 계약, 이 PR 은 상위 계약(팩토리 흡수) 을 각각 잠근다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)