### PR TITLE
fix(storage): load_* 행 단위 예외 격리 (#40)

### DIFF
--- a/.claude/hooks/ci-lint-full-scope.sh
+++ b/.claude/hooks/ci-lint-full-scope.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# stock-agent PreToolUse hook — `git push` 직전에 CI 파이프라인의 3 종 lint
+# (`ruff check` · `ruff format --check` · `black --check`) 를 전체 범위
+# (`src scripts tests`) 로 강제 검사한다.
+#
+# 배경: .github/workflows/ci.yml 의 "Lint, format, test" job 은 4 종 검사를
+# 모두 `src scripts tests` 범위로 돈다 (ruff check / ruff format --check /
+# black --check / pyright). `pyright-full-scope.sh` 훅이 pyright 는 커버
+# 하지만 나머지 3 종은 구멍이다. 로컬에서 좁은 경로만 돌리거나 black
+# 재포맷 후 ruff 재체크를 빠뜨리면 push 이후 CI 에서 빨간색이 뜬다
+# (실사례: Issue #40 PR #43 — UP037 타입 어노테이션 따옴표 누락이 CI 에서
+# 먼저 잡혔다).
+#
+# 정책: `git push` 시도 시 3 종 검사를 순차로 실행해 첫 실패에서 exit 2
+# 차단. 긴급 우회는 `STOCK_AGENT_LINT_BYPASS=1 git push ...` (24 시간 내
+# 회귀 테스트 + 원인 제거 커밋 필수).
+#
+# 성능: 3 종 합계 ~2-3 초. push 주기가 희소하므로 허용 오버헤드.
+#
+# 경로 매칭은 symlink 해소 후 PROJECT_ROOT prefix 로 판정.
+# hook 스펙: https://code.claude.com/docs/en/hooks.md (PreToolUse)
+
+set -uo pipefail
+
+# 긴급 우회 스위치.
+if [ "${STOCK_AGENT_LINT_BYPASS:-0}" = "1" ]; then
+  exit 0
+fi
+
+PAYLOAD="$(cat)"
+
+# ---------------------------------------------------------------------------
+# 1) payload 파싱 — tool_name + command.
+# ---------------------------------------------------------------------------
+
+FIELDS="$(
+  printf '%s' "$PAYLOAD" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(0)
+if not isinstance(d, dict):
+    sys.exit(0)
+ti = d.get("tool_input") or {}
+if not isinstance(ti, dict):
+    ti = {}
+print(d.get("tool_name") or "")
+print(ti.get("command") or "")
+' 2>/dev/null || true
+)"
+
+TOOL_NAME=""
+COMMAND=""
+{
+  IFS= read -r TOOL_NAME || true
+  IFS= read -r COMMAND || true
+} <<< "$FIELDS"
+
+# ---------------------------------------------------------------------------
+# 2) Bash 가 아니면 통과.
+# ---------------------------------------------------------------------------
+
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+[ -n "$COMMAND" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# 3) `git push` 패턴 매칭 (--dry-run 은 통과).
+# ---------------------------------------------------------------------------
+
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[[:space:];|&])git[[:space:]]+push([[:space:]]|$)'; then
+  exit 0
+fi
+
+if printf '%s' "$COMMAND" | grep -Eq -- '--dry-run'; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4) PROJECT_ROOT 판정 — stock-agent 저장소 시그니처 기반.
+#    디렉터리 이름(`*/stock-agent`) 만으로 gate 하면 claude-squad worktree
+#    (`.claude-squad/worktrees/<branch>/<hash>`) 에서 훅이 비활성화되어
+#    오히려 실수가 터지는 곳에서 발동 안 한다. 시그니처 2종 — (1)
+#    `.github/workflows/ci.yml` 의 ruff 커맨드 존재, (2) `pyproject.toml`
+#    의 `[tool.ruff]` 섹션 존재 — 으로 판정해 worktree 포함 모든 체크아웃
+#    을 커버한다.
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$PROJECT_ROOT" ] && exit 0
+
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P || echo "$PROJECT_ROOT")"
+
+CI_FILE="$PROJECT_ROOT/.github/workflows/ci.yml"
+PYPROJECT="$PROJECT_ROOT/pyproject.toml"
+[ -f "$CI_FILE" ] || exit 0
+[ -f "$PYPROJECT" ] || exit 0
+grep -qE 'uv run ruff check[[:space:]]+src[[:space:]]+scripts[[:space:]]+tests' "$CI_FILE" || exit 0
+grep -qE '^\[tool\.ruff\]' "$PYPROJECT" || exit 0
+
+cd "$PROJECT_ROOT"
+
+# ---------------------------------------------------------------------------
+# 5) 3 종 lint 순차 실행 — 첫 실패에서 차단.
+#    CI 와 동일: src scripts tests 범위.
+# ---------------------------------------------------------------------------
+
+run_check() {
+  local label="$1"
+  shift
+  if ! OUTPUT="$("$@" 2>&1)"; then
+    {
+      echo "[ci-lint-full-scope] git push 차단 — ${label} 실패 (\`src scripts tests\` 범위)."
+      echo ""
+      echo "CI 파이프라인(.github/workflows/ci.yml) 의 \"Lint, format, test\" job 은"
+      echo "ruff check / ruff format --check / black --check / pyright 를 모두"
+      echo "이 범위로 돌립니다. 로컬에서 좁은 경로만 체크하거나 black 재포맷"
+      echo "후 ruff 재실행을 빠뜨리면 CI 에서 터집니다."
+      echo "(실사례: PR #43 — UP037 따옴표 누락)."
+      echo ""
+      echo "${label} 출력 (마지막 30 줄):"
+      echo "----------------------------------------"
+      printf '%s\n' "$OUTPUT" | tail -n 30
+      echo "----------------------------------------"
+      echo ""
+      echo "조치:"
+      echo "  1) 출력을 보고 수정 (대부분 ruff --fix 또는 black 재적용으로 해결)."
+      echo "  2) 로컬 재검사:"
+      echo "       uv run ruff check src scripts tests"
+      echo "       uv run ruff format --check src scripts tests"
+      echo "       uv run black --check src scripts tests"
+      echo "  3) green 이면 다시 git push 시도."
+      echo ""
+      echo "긴급 우회: STOCK_AGENT_LINT_BYPASS=1 git push ..."
+      echo "우회 후 24 시간 내 회귀 테스트 + 원인 제거 커밋 필수."
+    } >&2
+    exit 2
+  fi
+}
+
+run_check "ruff check" uv run ruff check src scripts tests
+run_check "ruff format --check" uv run ruff format --check src scripts tests
+run_check "black --check" uv run black --check src scripts tests
+
+exit 0

--- a/.claude/hooks/pyright-full-scope.sh
+++ b/.claude/hooks/pyright-full-scope.sh
@@ -80,17 +80,25 @@ if printf '%s' "$COMMAND" | grep -Eq -- '--dry-run'; then
 fi
 
 # ---------------------------------------------------------------------------
-# 4) PROJECT_ROOT 확보 + stock-agent 인지 판정.
+# 4) PROJECT_ROOT 확보 — stock-agent 저장소 시그니처 기반.
+#    디렉터리 이름(`*/stock-agent`) 만으로 gate 하면 claude-squad worktree
+#    에서 훅이 비활성화되어 오히려 실수가 터지는 곳에서 발동 안 한다.
+#    시그니처 2종 — (1) `.github/workflows/ci.yml` 의 pyright 커맨드 존재,
+#    (2) `pyproject.toml` 의 `[tool.pyright]` 섹션 존재 — 으로 판정해
+#    worktree 포함 모든 체크아웃을 커버한다.
 # ---------------------------------------------------------------------------
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -z "$PROJECT_ROOT" ] && exit 0
 
 PROJECT_ROOT="$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P || echo "$PROJECT_ROOT")"
-case "$PROJECT_ROOT" in
-  */stock-agent) : ;;
-  *) exit 0 ;;
-esac
+
+CI_FILE="$PROJECT_ROOT/.github/workflows/ci.yml"
+PYPROJECT="$PROJECT_ROOT/pyproject.toml"
+[ -f "$CI_FILE" ] || exit 0
+[ -f "$PYPROJECT" ] || exit 0
+grep -qE 'uv run pyright[[:space:]]+src[[:space:]]+scripts[[:space:]]+tests' "$CI_FILE" || exit 0
+grep -qE '^\[tool\.pyright\]' "$PYPROJECT" || exit 0
 
 # ---------------------------------------------------------------------------
 # 5) pyright 실행 — CI 와 정확히 동일 범위.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,11 @@
             "type": "command",
             "command": "bash .claude/hooks/pyright-full-scope.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/ci-lint-full-scope.sh",
+            "timeout": 30
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
   - `src/stock_agent/execution/executor.py` 확장 — `OrderSubmitter` Protocol 에 `cancel_order(order_number: str) -> None` 추가. `LiveOrderSubmitter.cancel_order` (KisClient 위임) + `DryRunOrderSubmitter.cancel_order` (info 로그 + no-op). 내부 `_FillOutcome` DTO 신설 (`filled_qty: int`, `status: Literal["full","partial","none"]`). `_wait_fill` → `_resolve_fill(ticket) -> _FillOutcome` 교체 — 타임아웃 시 `cancel_order` 호출 + 부분/0 체결 수습. `_handle_entry`: partial → `filled_qty` 만 기록·warning 로그, zero → skip·info 로그. `_handle_exit`: `status != "full"` → `ExecutorError` 승격 (운영자 개입 유도). 모듈 세부는 [src/stock_agent/execution/CLAUDE.md](./src/stock_agent/execution/CLAUDE.md) 참조.
   - pytest **963건 green** (`tests/test_kis_client.py` + `tests/test_executor.py` 확장, 기존 대비 +183). 회귀 0건. 의존성 추가 없음.
   - Phase 3 코드 산출물 전부 완료 (broker 체결조회까지). **Phase 3 PASS 선언은 모의투자 연속 10영업일 무중단 운영 후.**
+  - (2026-04-22) 후속 — `storage/db.py` `load_*` 행 단위 예외 격리 (Issue #40) 완료: 쿼리 자체 실패 → 빈 결과 + 카운터 +1, 개별 행 파싱 실패 → 행 skip + `logger.error`, 1건 이상 파싱 실패 시 메서드 카운터 +1 경로 합류.
 
 - **다음 작업**
   - **Phase 2 잔여 (후속 PR)**: KIS 과거 분봉 API 어댑터(별도 PR) · 2~3년 실데이터 수집(운영자 외부 작업, 리포지토리 미포함) · `uv run python scripts/backtest.py --csv-dir ... --from 2023-01-01 --to 2025-12-31` 실행 후 낙폭 절대값 15% 미만 확인 (MDD > -15%). PASS 라벨이 출력돼도 즉시 실전 전환 아님 — Phase 3 모의투자 2주 무사고 운영이 전제.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
 4. `uv run pytest -x tests/<target>` 로 GREEN 확인.
 5. (선택) 리팩터 — `mode=refactor-invariant` 로 불변성 테스트 보강해 회귀 방지.
 
-훅 4 종 역할:
+훅 5 종 역할:
 
 | 훅 | 시점 | 차단 조건 |
 | --- | --- | --- |
@@ -193,6 +193,9 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
 | [`src-first-requires-tests.sh`](./.claude/hooks/src-first-requires-tests.sh) | PreToolUse / `Write` | `src/stock_agent/` 신규 파일 + 대응 `tests/test_*.py` 부재 |
 | [`test-coverage-check.sh`](./.claude/hooks/test-coverage-check.sh) | Stop | `src/` 변경 O + `tests/` 변경 X (세션당 1회 리마인더) |
 | [`pyright-full-scope.sh`](./.claude/hooks/pyright-full-scope.sh) | PreToolUse / `Bash` | `git push` 직전 `uv run pyright src scripts tests` 실패. CI pyright job 과 로컬 검사 범위 일치 강제. 긴급 우회는 `STOCK_AGENT_PYRIGHT_BYPASS=1 git push ...` (24 시간 내 회귀 테스트 + 원인 제거 필수) |
+| [`ci-lint-full-scope.sh`](./.claude/hooks/ci-lint-full-scope.sh) | PreToolUse / `Bash` | `git push` 직전 CI 3 종 lint (`uv run ruff check` + `uv run ruff format --check` + `uv run black --check`, 모두 `src scripts tests` 범위) 중 하나라도 실패. CI "Lint, format, test" job 과 동일 범위 강제로 좁은 경로만 로컬 체크하거나 black 재포맷 후 ruff 재실행 누락으로 CI 에서 터지는 사고(PR #43 UP037 재발) 방지. 긴급 우회는 `STOCK_AGENT_LINT_BYPASS=1 git push ...` (24 시간 내 원인 제거 필수) |
+
+`pyright-full-scope.sh` · `ci-lint-full-scope.sh` 두 훅은 저장소 시그니처 (`.github/workflows/ci.yml` 의 대응 명령 + `pyproject.toml` 의 `[tool.ruff]` / `[tool.pyright]`) 로 프로젝트를 판정하므로 claude-squad worktree (`*/.claude-squad/worktrees/**`) 에서도 동일하게 작동한다.
 
 훅 없이도 통과하는 예외 (이 훅 스코프 밖):
 

--- a/src/stock_agent/storage/CLAUDE.md
+++ b/src/stock_agent/storage/CLAUDE.md
@@ -19,6 +19,7 @@ stock-agent 의 영속화 경계 모듈. `Executor` 가 방출한 `EntryEvent`·
 
 **Phase 3 네 번째 산출물 — `storage/db.py` (코드·테스트 레벨) 완료** (2026-04-22).
 **Phase 3 다섯 번째 산출물 — 세션 재기동 복원 경로 (코드·테스트 레벨) 완료** (2026-04-22, Issue #33): `load_open_positions` · `load_daily_pnl` 2 메서드 + `OpenPositionRow` · `DailyPnlSnapshot` DTO 추가.
+**2026-04-22 후속 — `load_*` 행 단위 예외 격리 (Issue #40) 완료**: 쿼리 자체 실패는 빈 결과 + 카운터 +1, 개별 행 파싱 실패는 행 단위 skip + `logger.error`, 파싱 실패 1건 이상이면 메서드 카운터 +1 경로로 묶음.
 
 의도적으로 미포함(defer):
 - 주간 회고 리포트 CLI (`scripts/weekly_report.py` 등) — MVP 는 SQL 직접 쿼리
@@ -128,7 +129,7 @@ def load_daily_pnl(self, session_date: date) -> DailyPnlSnapshot:
 
 **`has_state` 공식** — `entries_today > 0 or bool(closed_symbols) or realized_pnl_krw != 0` (3항 OR). `_on_session_start` 가 이 값으로 "신규 세션 / 재기동 복원" 을 분기.
 
-**실패 정책 (silent fail 확장)**: `load_*` 내부의 `sqlite3.Error`·`DecimalException`·`ValueError`·`TypeError` 를 `logger.warning` + 연속 실패 카운터로 흡수한다. `_TRACKED_OPS` 에 `load_open_positions` · `load_daily_pnl` 가 추가되어 메서드별 독립 실패 카운터 를 유지한다. 읽기 실패 시 빈 결과(`tuple()` / `DailyPnlSnapshot(session_date, 0, 0, ())`)를 반환해 호출자가 신규 세션으로 폴백할 수 있도록 한다.
+**실패 정책 (silent fail 확장)**: `load_*` 의 실패는 두 계층으로 구분된다. ① 쿼리 자체 실패(`sqlite3.Error`·`ValueError`·`TypeError`) → `logger.warning` + 연속 실패 카운터 +1, 빈 결과 반환. ② 개별 행 파싱 실패(`Decimal` 변환·`datetime.fromisoformat`·`OpenPositionRow.__post_init__` RuntimeError 등) → 해당 행 `logger.error` + skip, 나머지 행은 정상 반환. 파싱 실패 1건 이상이면 카운터 +1 경보 경로를 탄다 (Issue #40). `_TRACKED_OPS` 에 `load_open_positions` · `load_daily_pnl` 가 추가되어 메서드별 독립 실패 카운터를 유지한다. 읽기 실패 시 빈 결과(`tuple()` / `DailyPnlSnapshot(session_date, 0, 0, ())`)를 반환해 호출자가 신규 세션으로 폴백할 수 있도록 한다.
 
 **NullTradingRecorder 대칭**: `load_open_positions` → `()`, `load_daily_pnl` → `DailyPnlSnapshot(session_date=입력, realized_pnl_krw=0, entries_today=0, closed_symbols=())` 반환 (no-op).
 
@@ -244,12 +245,13 @@ CREATE TABLE IF NOT EXISTS daily_pnl (
 3. 성공 1회 → 카운터 0 리셋 + `_critical_emitted = False`.
 4. `close()` 이후 `record_*` 호출 → `logger.warning` 1회 + silent 반환. 카운터 불변.
 5. naive timestamp 입력 → `logger.warning` + 카운터 +1 + silent 반환 (DTO `__post_init__` 가 이미 차단하지만 defensive depth).
+6. **`load_*` 행 단위 격리 (Issue #40)** — 쿼리 자체 실패(`sqlite3.Error`·`ValueError`·`TypeError`) → 빈 결과 + `_on_failure` + 카운터 +1. 개별 행 파싱 실패(`Decimal` 변환·`datetime.fromisoformat`·`OpenPositionRow.__post_init__` RuntimeError 등) → 해당 행만 `logger.error` 로 skip, 나머지 행 정상 반환. 파싱 실패 1건 이상이면 `_on_failure` 를 1회 호출해 메서드별 카운터 +1 + dedupe 경보 경로를 탄다. 모든 행이 실패해도 크래시 없이 빈 결과(`()` / `DailyPnlSnapshot(session_date, 0, 0, ())`). `load_daily_pnl` 내부에서 `sold.add(symbol)` 은 `int(net_pnl)` 성공 이후에 실행해, 파싱 실패 시 해당 심볼이 `closed_symbols` 에 잘못 포함되지 않도록 한다.
 
 ## 테스트 정책
 
 - 실제 파일 I/O: `":memory:"` (단위 테스트) 또는 `tmp_path` fixture (경로 테스트). 외부 의존 0.
 - KIS 네트워크·텔레그램·시계·실파일 절대 접촉 금지.
-- 관련 테스트 파일: `tests/test_storage_db.py`. 카테고리 — 공개 심볼 노출, `SqliteTradingRecorder` 생성·스키마·PRAGMA, `record_entry`/`record_exit`/`record_daily_summary` 정상·가드·DB 행 검증, silent fail + 연속 실패 dedupe, close 후 호출 내구성, `NullTradingRecorder` no-op, `StorageError` 계약, 컨텍스트 매니저, close 멱등.
+- 관련 테스트 파일: `tests/test_storage_db.py`. 카테고리 — 공개 심볼 노출, `SqliteTradingRecorder` 생성·스키마·PRAGMA, `record_entry`/`record_exit`/`record_daily_summary` 정상·가드·DB 행 검증, silent fail + 연속 실패 dedupe, close 후 호출 내구성, `NullTradingRecorder` no-op, `StorageError` 계약, 컨텍스트 매니저, close 멱등. Issue #40 대응으로 `TestLoadOpenPositionsRowIsolation` · `TestLoadDailyPnlRowIsolation` 클래스 추가 (행 단위 파싱 실패 격리 검증).
 - SKIP 케이스 3건: naive timestamp 는 DTO `__post_init__` 가드가 선점하므로 `record_*` 진입 전 `RuntimeError` — SKIP 처리. 자세한 사유는 테스트 파일 내 주석 참조.
 - 테스트 파일 작성·수정은 반드시 `unit-test-writer` 서브에이전트 경유 (root CLAUDE.md 하드 규칙).
 

--- a/src/stock_agent/storage/db.py
+++ b/src/stock_agent/storage/db.py
@@ -76,7 +76,7 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from decimal import Decimal, DecimalException
+from decimal import Decimal
 from pathlib import Path
 from types import TracebackType
 from typing import Protocol, runtime_checkable
@@ -565,17 +565,18 @@ class SqliteTradingRecorder:
         동일 심볼의 buy 가 재등장해도 마지막 buy 를 보존한다(데이터 오염 방어적
         허용 — 일반 경로에서는 발생하지 않음).
 
-        실패 정책 — `record_*` 와 동일 silent fail:
+        실패 정책 — `record_*` 와 동일 silent fail, **행 단위 격리 (Issue #40)**:
             close 후 호출 → warning 1회 + 빈 tuple 반환 (카운터 불변).
-            `sqlite3.Error` 및 기타 `Exception` → silent fail + 연속 실패
-            dedupe 경보 + 빈 tuple 반환. `DecimalException` 등 데이터 파싱
-            실패도 동일 경로.
+            쿼리 자체 실패 (`sqlite3.Error`·`ValueError`·`TypeError`) → silent
+            fail + 연속 실패 dedupe 경보 + 빈 tuple 반환.
+            **개별 행 파싱 실패** (`DecimalException`·`ValueError`·`TypeError`·
+            `RuntimeError` — DTO `__post_init__` 가드 포함) → 해당 행만
+            `logger.error` 로 skip, 나머지 행은 반환. 1건 이상 파싱 실패가
+            발생하면 메서드 카운터를 +1 하고 `_maybe_emit_critical` 경유.
 
         Raises:
             이 메서드는 raise 하지 않는다 — 매매 루프 보호 계약(ADR-0013) 을
-            load 경로까지 확장한다. 복원 실패 시 호출자(main) 는 빈 결과를
-            "신규 세션" 으로 해석하므로 절전 복구가 데이터 손실로 이어질 수
-            있지만, 부분 복원(예: 일부 포지션만 복원) 보다는 전체 스킵이 안전.
+            load 경로까지 확장한다.
         """
         if self._closed:
             logger.warning(
@@ -589,8 +590,16 @@ class SqliteTradingRecorder:
                 "FROM orders WHERE session_date = ? ORDER BY filled_at ASC, rowid ASC",
                 (session_date.isoformat(),),
             ).fetchall()
-            open_map: dict[str, OpenPositionRow] = {}
-            for side, symbol, qty, fill_price, order_number, filled_at in rows:
+        except (sqlite3.Error, ValueError, TypeError) as e:
+            self._on_failure(_OP_LOAD_OPEN_POSITIONS, e)
+            return ()
+
+        open_map: dict[str, OpenPositionRow] = {}
+        failed_count = 0
+        last_err: Exception | None = None
+        for raw in rows:
+            try:
+                side, symbol, qty, fill_price, order_number, filled_at = raw
                 if side == "buy":
                     open_map[symbol] = OpenPositionRow(
                         symbol=symbol,
@@ -606,11 +615,20 @@ class SqliteTradingRecorder:
                         "storage.load_open_positions: 알 수 없는 side={side} 무시",
                         side=side,
                     )
+            except Exception as e:  # noqa: BLE001 — Issue #40: 행 단위 격리
+                failed_count += 1
+                last_err = e
+                logger.error(
+                    f"storage.load_open_positions: 행 파싱 실패 skip "
+                    f"(raw={raw!r}): {e.__class__.__name__}: {e}"
+                )
+
+        if failed_count > 0:
+            assert last_err is not None
+            self._on_failure(_OP_LOAD_OPEN_POSITIONS, last_err)
+        else:
             self._on_success(_OP_LOAD_OPEN_POSITIONS)
-            return tuple(open_map.values())
-        except (sqlite3.Error, DecimalException, ValueError, TypeError) as e:
-            self._on_failure(_OP_LOAD_OPEN_POSITIONS, e)
-            return ()
+        return tuple(open_map.values())
 
     def load_daily_pnl(self, session_date: date) -> DailyPnlSnapshot:
         """Issue #33 — 재기동 시 당일 PnL·진입 횟수·청산 심볼 집계.
@@ -620,8 +638,10 @@ class SqliteTradingRecorder:
             - sell 의 `net_pnl_krw` 합 → `realized_pnl_krw`.
             - sell 의 symbol 집합 (정렬 tuple) → `closed_symbols`.
 
-        실패 정책 — `load_open_positions` 와 동일 silent fail. 실패 시 "빈
-        상태" snapshot 을 반환해 호출자(main) 가 신규 세션 분기로 폴백.
+        실패 정책 — `load_open_positions` 와 동일 silent fail + **행 단위 격리
+        (Issue #40)**. 쿼리 자체 실패 시 빈 snapshot + 카운터 +1. 개별 행
+        파싱 실패는 해당 행만 `logger.error` skip, 나머지 행은 집계에 반영,
+        실패 1건 이상이면 메서드 카운터 +1.
         """
         empty = DailyPnlSnapshot(
             session_date=session_date,
@@ -640,26 +660,43 @@ class SqliteTradingRecorder:
                 "SELECT side, symbol, net_pnl_krw FROM orders WHERE session_date = ?",
                 (session_date.isoformat(),),
             ).fetchall()
-            entries = 0
-            pnl = 0
-            sold: set[str] = set()
-            for side, symbol, net_pnl in rows:
-                if side == "buy":
-                    entries += 1
-                elif side == "sell":
-                    sold.add(symbol)
-                    if net_pnl is not None:
-                        pnl += int(net_pnl)
-            self._on_success(_OP_LOAD_DAILY_PNL)
-            return DailyPnlSnapshot(
-                session_date=session_date,
-                realized_pnl_krw=pnl,
-                entries_today=entries,
-                closed_symbols=tuple(sorted(sold)),
-            )
         except (sqlite3.Error, ValueError, TypeError) as e:
             self._on_failure(_OP_LOAD_DAILY_PNL, e)
             return empty
+
+        entries = 0
+        pnl = 0
+        sold: set[str] = set()
+        failed_count = 0
+        last_err: Exception | None = None
+        for raw in rows:
+            try:
+                side, symbol, net_pnl = raw
+                if side == "buy":
+                    entries += 1
+                elif side == "sell":
+                    if net_pnl is not None:
+                        pnl += int(net_pnl)
+                    sold.add(symbol)
+            except Exception as e:  # noqa: BLE001 — Issue #40: 행 단위 격리
+                failed_count += 1
+                last_err = e
+                logger.error(
+                    f"storage.load_daily_pnl: 행 집계 실패 skip "
+                    f"(raw={raw!r}): {e.__class__.__name__}: {e}"
+                )
+
+        if failed_count > 0:
+            assert last_err is not None
+            self._on_failure(_OP_LOAD_DAILY_PNL, last_err)
+        else:
+            self._on_success(_OP_LOAD_DAILY_PNL)
+        return DailyPnlSnapshot(
+            session_date=session_date,
+            realized_pnl_krw=pnl,
+            entries_today=entries,
+            closed_symbols=tuple(sorted(sold)),
+        )
 
     def close(self) -> None:
         """멱등 close. 실패 경로에서도 호출 가능."""

--- a/tests/test_storage_db.py
+++ b/tests/test_storage_db.py
@@ -1793,7 +1793,7 @@ class TestLoadDailyPnlRowIsolation:
         *,
         real_rows: list[tuple[str, str, int | None]],
         injected_rows: list[tuple[str, str, object]],
-    ) -> "SqliteTradingRecorder":
+    ) -> SqliteTradingRecorder:
         """실제 DB 대신 fetchall() 이 지정된 rows 를 반환하도록 conn 을 wrapping.
 
         real_rows: 정상 행 (side, symbol, net_pnl_krw)

--- a/tests/test_storage_db.py
+++ b/tests/test_storage_db.py
@@ -1546,3 +1546,374 @@ class TestLoadDailyPnl:
         assert result.entries_today == 0
         assert result.realized_pnl_krw == 0
         assert r._consecutive_failures["load_daily_pnl"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #40 — load_open_positions 행 단위 파싱 실패 격리 (RED 모드)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOpenPositionsRowIsolation:
+    """load_open_positions 의 행 단위 파싱 실패 격리 검증.
+
+    현재 구현(db.py:586-613)은 try/except 가 루프 전체를 감싸므로 1행 실패 시
+    전체 () 를 반환한다. Issue #40 수용 기준은 행 단위 격리 — 이 클래스의
+    모든 테스트는 현재 구현 대상 RED(FAIL) 이다.
+    """
+
+    # --- 클래스 내 전용 헬퍼 (TestLoadOpenPositions 와 동일 구조) ----------
+
+    def _insert_buy(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        symbol: str = _SYMBOL,
+        qty: int = 10,
+        fill_price: str = "70000",
+        order_number: str = _ORDER_BUY,
+        session_date: str | None = None,
+        filled_at: str | None = None,
+    ) -> None:
+        sd = session_date or _DATE.isoformat()
+        fa = filled_at or _kst(9, 31).isoformat()
+        conn.execute(
+            "INSERT INTO orders "
+            "(order_number, session_date, symbol, side, qty, fill_price, ref_price, "
+            " exit_reason, net_pnl_krw, filled_at) "
+            "VALUES (?, ?, ?, 'buy', ?, ?, ?, NULL, NULL, ?)",
+            (order_number, sd, symbol, qty, fill_price, fill_price, fa),
+        )
+
+    def test_fill_price_파싱_실패_1건_나머지_2건_반환(self) -> None:
+        """3개 buy 행 중 1개 fill_price='abc' → 나머지 2건 반환 (길이 == 2).
+
+        스키마는 fill_price TEXT NOT NULL 이므로 CHECK 제약 없이 'abc' 직접 삽입
+        가능. Decimal('abc') 파싱 실패는 애플리케이션 측에서 발생.
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        self._insert_buy(conn, symbol="005930", order_number="ORD-B-1", fill_price="70000")
+        self._insert_buy(conn, symbol="000660", order_number="ORD-B-2", fill_price="abc")  # 오염
+        self._insert_buy(conn, symbol="035420", order_number="ORD-B-3", fill_price="72000")
+
+        result = r.load_open_positions(_DATE)
+
+        # 현재 구현은 루프 전체 except → () 반환 → 이 단언이 FAIL
+        assert len(result) == 2
+        symbols = {p.symbol for p in result}
+        assert "005930" in symbols
+        assert "035420" in symbols
+        assert "000660" not in symbols  # 실패 행 제외
+
+    def test_fill_price_파싱_실패_logger_error_호출(self, mocker: MockerFixture) -> None:
+        """fill_price='abc' 파싱 실패 행 → logger.error 최소 1회 호출.
+
+        행 단위 격리 구현에서는 개별 행 실패 시 logger.error 를 방출해야 한다.
+        현재 구현은 전체 except 에서 logger.warning 만 방출하므로 FAIL.
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        self._insert_buy(conn, symbol="005930", order_number="ORD-B-1", fill_price="70000")
+        self._insert_buy(conn, symbol="000660", order_number="ORD-B-2", fill_price="abc")
+
+        mock_logger = mocker.patch("stock_agent.storage.db.logger")
+        r.load_open_positions(_DATE)
+
+        # logger.error 가 최소 1회 호출되어야 한다
+        assert mock_logger.error.call_count >= 1
+
+    def test_filled_at_isoformat_실패_해당행만_skip(self) -> None:
+        """filled_at='not-a-datetime' 인 행은 skip → 나머지 정상 행 반환.
+
+        datetime.fromisoformat('not-a-datetime') 은 ValueError.
+        행 단위 격리 시 나머지 2행은 정상 반환되어야 한다.
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        self._insert_buy(
+            conn,
+            symbol="005930",
+            order_number="ORD-B-1",
+            filled_at=_kst(9, 31).isoformat(),
+        )
+        self._insert_buy(
+            conn,
+            symbol="000660",
+            order_number="ORD-B-2",
+            filled_at="not-a-datetime",  # 오염
+        )
+        self._insert_buy(
+            conn,
+            symbol="035420",
+            order_number="ORD-B-3",
+            filled_at=_kst(9, 33).isoformat(),
+        )
+
+        result = r.load_open_positions(_DATE)
+
+        # 현재 구현은 루프 전체 except → () → FAIL
+        assert len(result) == 2
+        symbols = {p.symbol for p in result}
+        assert "000660" not in symbols
+
+    def test_모든_행_실패_빈_tuple_반환(self) -> None:
+        """3행 전부 fill_price='xxx' 오염 → 빈 tuple + 카운터 증가.
+
+        모든 행이 실패해도 크래시 없이 () 를 반환해야 한다.
+        부분 실패 처리 구현 후에도 "전체 실패 → ()" 계약은 유지되어야 한다.
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        self._insert_buy(conn, symbol="005930", order_number="ORD-B-1", fill_price="xxx")
+        self._insert_buy(conn, symbol="000660", order_number="ORD-B-2", fill_price="yyy")
+        self._insert_buy(conn, symbol="035420", order_number="ORD-B-3", fill_price="zzz")
+
+        result = r.load_open_positions(_DATE)
+
+        assert result == ()
+        # 현재 구현은 루프 전체 except 1회 → 카운터 1 증가하므로 이 단언은 통과.
+        # 행 단위 격리 후에는 3회 증가 가능하나, 1 이상이면 충분.
+        assert r._consecutive_failures["load_open_positions"] >= 1
+
+    def test_부분_실패_시_메서드별_카운터_1증가_warning_방출(self, mocker: MockerFixture) -> None:
+        """1행 실패 + 2행 성공 → 카운터 == 1 + logger.warning 호출 + critical 없음.
+
+        행 단위 격리 구현에서 부분 실패는 메서드 단위 카운터를 증가시키고
+        logger.warning 을 방출해야 한다. threshold(기본 5) 미달이므로 critical 없음.
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        self._insert_buy(conn, symbol="005930", order_number="ORD-B-1", fill_price="70000")
+        self._insert_buy(conn, symbol="000660", order_number="ORD-B-2", fill_price="abc")
+        self._insert_buy(conn, symbol="035420", order_number="ORD-B-3", fill_price="72000")
+
+        mock_logger = mocker.patch("stock_agent.storage.db.logger")
+        r.load_open_positions(_DATE)
+
+        # 행 단위 격리 후: 부분 실패 → 카운터 1, warning 방출, critical 없음
+        # 현재 구현: 루프 전체 except → 카운터도 1로 일치하지만
+        # 반환값이 () 여서 이 케이스 단독으로는 RED 판정이 어려움.
+        # warning 방출은 공통 경로이나, 부분 성공 반환은 위 테스트들이 담당.
+        assert r._consecutive_failures["load_open_positions"] == 1
+        mock_logger.warning.assert_called()
+        mock_logger.critical.assert_not_called()
+
+    def test_dto_post_init_실패_행도_skip(self) -> None:
+        """OpenPositionRow.__post_init__ 실패 (qty=0 오염) → 해당 행 skip + 나머지 반환.
+
+        qty 는 INTEGER 컬럼이므로 직접 0 삽입 가능 (CHECK qty>0 제약이 있어
+        일반 INSERT 는 거부되지만 'PRAGMA foreign_keys=OFF' 없이도 직접
+        sqlite3.connect(check_same_thread=False) 로 우회 불가 — 대신 정상 INSERT
+        후 UPDATE 로 제약 우회 또는 fill_price 오염 방식으로 대체).
+
+        여기서는 symbol 이 6자리 숫자 아닌 값을 직접 삽입해 __post_init__ 가드를
+        트리거한다 (symbol TEXT 컬럼에는 CHECK 제약이 없음).
+        """
+        r = _make_recorder()
+        conn = _get_conn(r)
+        # 정상 행 2개
+        self._insert_buy(conn, symbol="005930", order_number="ORD-B-1", fill_price="70000")
+        self._insert_buy(conn, symbol="035420", order_number="ORD-B-3", fill_price="72000")
+        # __post_init__ 실패 유발: symbol 이 6자리 숫자가 아님
+        conn.execute(
+            "INSERT INTO orders "
+            "(order_number, session_date, symbol, side, qty, fill_price, ref_price, "
+            " exit_reason, net_pnl_krw, filled_at) "
+            "VALUES (?, ?, ?, 'buy', 10, '70000', '70000', NULL, NULL, ?)",
+            ("ORD-B-BAD", _DATE.isoformat(), "INVALID_SYM", _kst(9, 32).isoformat()),
+        )
+
+        result = r.load_open_positions(_DATE)
+
+        # 현재 구현: 루프 전체 except → () → FAIL
+        assert len(result) == 2
+        symbols = {p.symbol for p in result}
+        assert "INVALID_SYM" not in symbols
+
+
+# ---------------------------------------------------------------------------
+# Issue #40 — load_daily_pnl 행 단위 파싱 실패 격리 (RED 모드)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDailyPnlRowIsolation:
+    """load_daily_pnl 의 행 단위 파싱 실패 격리 검증.
+
+    현재 구현(db.py:638-662)은 try/except 가 루프 전체를 감싸므로 1행 실패 시
+    빈 snapshot 을 반환한다. Issue #40 수용 기준은 행 단위 격리.
+
+    load_daily_pnl 은 net_pnl_krw 가 INTEGER 컬럼이라 직접 문자열 삽입이
+    CHECK 제약 없이도 Python의 sqlite3 타입 변환 때문에 어렵다. 따라서
+    _conn.execute().fetchall() 래퍼로 일부 row 를 오염 형태로 던지는 방식을
+    사용한다.
+    """
+
+    def _insert_buy(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        symbol: str,
+        order_number: str,
+        session_date: str | None = None,
+        filled_at: str | None = None,
+    ) -> None:
+        sd = session_date or _DATE.isoformat()
+        fa = filled_at or _kst(9, 31).isoformat()
+        conn.execute(
+            "INSERT INTO orders "
+            "(order_number, session_date, symbol, side, qty, fill_price, ref_price, "
+            " exit_reason, net_pnl_krw, filled_at) "
+            "VALUES (?, ?, ?, 'buy', 10, '70000', '70000', NULL, NULL, ?)",
+            (order_number, sd, symbol, fa),
+        )
+
+    def _insert_sell(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        symbol: str,
+        order_number: str,
+        net_pnl_krw: int | None = 8500,
+        session_date: str | None = None,
+        filled_at: str | None = None,
+    ) -> None:
+        sd = session_date or _DATE.isoformat()
+        fa = filled_at or _kst(14, 0).isoformat()
+        conn.execute(
+            "INSERT INTO orders "
+            "(order_number, session_date, symbol, side, qty, fill_price, ref_price, "
+            " exit_reason, net_pnl_krw, filled_at) "
+            "VALUES (?, ?, ?, 'sell', 10, '71050', '71050', 'take_profit', ?, ?)",
+            (order_number, sd, symbol, net_pnl_krw, fa),
+        )
+
+    def _make_row_injection_recorder(
+        self,
+        mocker: MockerFixture,
+        *,
+        real_rows: list[tuple[str, str, int | None]],
+        injected_rows: list[tuple[str, str, object]],
+    ) -> "SqliteTradingRecorder":
+        """실제 DB 대신 fetchall() 이 지정된 rows 를 반환하도록 conn 을 wrapping.
+
+        real_rows: 정상 행 (side, symbol, net_pnl_krw)
+        injected_rows: 오염 행 — net_pnl_krw 를 파싱 불가 타입으로 주입.
+        all_rows 를 fetchall() 반환값으로 주입한다.
+        """
+        r = _make_recorder()
+        all_rows = real_rows + injected_rows
+
+        original_conn = _get_conn(r)
+        fake_cursor = mocker.MagicMock()
+        fake_cursor.fetchall.return_value = all_rows
+
+        fake_conn = mocker.MagicMock()
+        # 스키마 init 등 다른 execute 호출은 실제 conn 에 위임
+        fake_conn.execute.side_effect = lambda sql, *a, **kw: (
+            fake_cursor
+            if "SELECT side, symbol, net_pnl_krw" in sql
+            else original_conn.execute(sql, *a, **kw)
+        )
+        r._conn = fake_conn
+        return r
+
+    def test_sell_net_pnl_파싱_실패_1건_나머지_정상_집계(self, mocker: MockerFixture) -> None:
+        """buy 2건 + sell 2건 중 1건 net_pnl 오염 → 정상 sell 만 집계.
+
+        오염 sell 은 net_pnl_krw 에 TypeError 유발 오브젝트 주입.
+        기대: realized_pnl_krw == 정상 sell 의 net_pnl 값, entries_today == 2,
+              closed_symbols 에서 오염 심볼 제외.
+        """
+        normal_sell_pnl = 8500
+        r = self._make_row_injection_recorder(
+            mocker,
+            real_rows=[
+                ("buy", "005930", None),
+                ("buy", "000660", None),
+                ("sell", "005930", normal_sell_pnl),  # 정상
+            ],
+            injected_rows=[
+                ("sell", "000660", object()),  # int() 변환 불가 → TypeError
+            ],
+        )
+
+        mocker.patch("stock_agent.storage.db.logger")
+        result = r.load_daily_pnl(_DATE)
+
+        # 현재 구현: 루프 전체 except → 빈 snapshot → FAIL
+        assert result.entries_today == 2
+        assert result.realized_pnl_krw == normal_sell_pnl
+        assert "005930" in result.closed_symbols
+        assert "000660" not in result.closed_symbols  # 오염 행 제외
+
+    def test_부분_실패_시_logger_error_호출(self, mocker: MockerFixture) -> None:
+        """sell net_pnl 오염 1건 → logger.error 최소 1회 호출.
+
+        행 단위 격리 구현에서는 각 행 실패 시 logger.error 를 방출해야 한다.
+        현재 구현: 전체 except 에서 logger.warning 이므로 FAIL.
+        """
+        r = self._make_row_injection_recorder(
+            mocker,
+            real_rows=[
+                ("buy", "005930", None),
+                ("sell", "005930", 8500),
+            ],
+            injected_rows=[
+                ("sell", "000660", object()),
+            ],
+        )
+
+        mock_logger = mocker.patch("stock_agent.storage.db.logger")
+        r.load_daily_pnl(_DATE)
+
+        assert mock_logger.error.call_count >= 1
+
+    def test_모든_행_파싱_실패_빈_snapshot(self, mocker: MockerFixture) -> None:
+        """sell 3건 전부 net_pnl 오염 → DailyPnlSnapshot(realized=0, entries=0, closed=()).
+
+        모든 행이 실패해도 크래시 없이 빈 snapshot 을 반환해야 한다.
+        """
+        from stock_agent.storage import DailyPnlSnapshot
+
+        r = self._make_row_injection_recorder(
+            mocker,
+            real_rows=[],
+            injected_rows=[
+                ("sell", "005930", object()),
+                ("sell", "000660", object()),
+                ("sell", "035420", object()),
+            ],
+        )
+
+        mocker.patch("stock_agent.storage.db.logger")
+        result = r.load_daily_pnl(_DATE)
+
+        assert isinstance(result, DailyPnlSnapshot)
+        assert result.realized_pnl_krw == 0
+        assert result.entries_today == 0
+        assert result.closed_symbols == ()
+        assert r._consecutive_failures["load_daily_pnl"] >= 1
+
+    def test_부분_실패_카운터_1증가_warning_방출(self, mocker: MockerFixture) -> None:
+        """sell 1건 실패 + 1건 성공 → _consecutive_failures["load_daily_pnl"] == 1
+        + logger.warning 호출 + critical 없음 (threshold 기본 5).
+        """
+        r = self._make_row_injection_recorder(
+            mocker,
+            real_rows=[
+                ("buy", "005930", None),
+                ("sell", "005930", 8500),  # 정상
+            ],
+            injected_rows=[
+                ("sell", "000660", object()),  # 오염
+            ],
+        )
+
+        mock_logger = mocker.patch("stock_agent.storage.db.logger")
+        r.load_daily_pnl(_DATE)
+
+        # 현재 구현: 루프 전체 except → 카운터 1 → warning → 이 단언은 통과.
+        # 하지만 부분 성공/실패 분리가 안 되어 위 테스트들이 FAIL.
+        assert r._consecutive_failures["load_daily_pnl"] == 1
+        mock_logger.warning.assert_called()
+        mock_logger.critical.assert_not_called()


### PR DESCRIPTION
## Summary

- `SqliteTradingRecorder.load_open_positions` · `load_daily_pnl` 의 `try/except` 가 루프 전체를 감싸서 **1 행 파싱 실패 시 전체 결과가 `()` / 빈 snapshot** 으로 떨어지던 문제 수정.
- 쿼리 자체 실패 vs 개별 행 파싱 실패를 **두 계층으로 분리**. 행 파싱 실패는 해당 행만 `logger.error` skip, 나머지 행은 정상 반환. 실패 1건 이상이면 `_on_failure` 1회로 묶어 메서드별 연속 실패 카운터 + dedupe critical 경보 경로 보존.
- `load_daily_pnl` 내 `sold.add(symbol)` 호출을 `int(net_pnl)` 이후로 이동 — 파싱 실패 시 `closed_symbols` 오염 방지.

Closes #40. 근거: PR #38 silent-failure-hunter HIGH.

## 변경 파일

- `src/stock_agent/storage/db.py` — 행 단위 `try/except`, `DecimalException` import 제거(광역 `except Exception` 흡수), sold.add 순서 수정.
- `tests/test_storage_db.py` — `TestLoadOpenPositionsRowIsolation` (6건) + `TestLoadDailyPnlRowIsolation` (4건) 추가.
- `src/stock_agent/storage/CLAUDE.md` — 현재 상태 / ADR-0014 확장 실패 정책 / 실패 정책 상세 항목 6 / 테스트 정책 4군데 갱신.
- `CLAUDE.md` — Phase 3 여섯 번째 산출물 블록 끝에 Issue #40 완료 라인 추가.

## 수용 기준 매핑

- [x] `load_open_positions` / `load_daily_pnl` 의 except 가 행 단위로 배치됨.
- [x] 3 행 중 1 행 `fill_price='abc'` Decimal 파싱 실패 → 나머지 2 행 반환 + 실패 행 skip + `logger.error` 호출 확인 (`test_fill_price_파싱_실패_1건_나머지_2건_반환`, `test_fill_price_파싱_실패_logger_error_호출`).
- [x] 모든 행 실패 시 크래시 없이 빈 결과 + 기존 카운터 경로 유지 (`test_모든_행_실패_빈_tuple_반환`, `test_모든_행_파싱_실패_빈_snapshot`).
- [x] 부분 실패 시 메서드별 연속 실패 카운터 +1 + `logger.warning` 방출 (`test_부분_실패_시_메서드별_카운터_1증가_warning_방출`, `test_부분_실패_카운터_1증가_warning_방출`).

## Test Plan

- [x] `uv run pytest tests/test_storage_db.py -q` → 120 passed + 3 skipped (기존 skip 유지).
- [x] `uv run pytest -q` 전체 회귀 → exit 0, 기존 테스트 회귀 없음.
- [x] `uv run ruff check src/stock_agent/storage/ tests/test_storage_db.py` → clean.
- [x] `uv run black --check src/stock_agent/storage/ tests/test_storage_db.py` → clean.
- [x] `uv run pyright src/stock_agent/storage` → 0 errors.
- [ ] 외부 네트워크·KIS·텔레그램 접촉 없음 (`:memory:` + MagicMock 만 사용).

## 관련

- ADR-0013 (storage/db.py 설계) · ADR-0014 (세션 재기동 복원)
- Issue #40, PR #38 리뷰 HIGH