### PR TITLE
feat(main): NullTradingRecorder 폴백 critical 경보 — _on_session_start 가시성 (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
   - `src/stock_agent/execution/executor.py` 확장 — `OrderSubmitter` Protocol 에 `cancel_order(order_number: str) -> None` 추가. `LiveOrderSubmitter.cancel_order` (KisClient 위임) + `DryRunOrderSubmitter.cancel_order` (info 로그 + no-op). 내부 `_FillOutcome` DTO 신설 (`filled_qty: int`, `status: Literal["full","partial","none"]`). `_wait_fill` → `_resolve_fill(ticket) -> _FillOutcome` 교체 — 타임아웃 시 `cancel_order` 호출 + 부분/0 체결 수습. `_handle_entry`: partial → `filled_qty` 만 기록·warning 로그, zero → skip·info 로그. `_handle_exit`: `status != "full"` → `ExecutorError` 승격 (운영자 개입 유도). 모듈 세부는 [src/stock_agent/execution/CLAUDE.md](./src/stock_agent/execution/CLAUDE.md) 참조.
   - pytest **963건 green** (`tests/test_kis_client.py` + `tests/test_executor.py` 확장, 기존 대비 +183). 회귀 0건. 의존성 추가 없음.
   - Phase 3 코드 산출물 전부 완료 (broker 체결조회까지). **Phase 3 PASS 선언은 모의투자 연속 10영업일 무중단 운영 후.**
+  - (2026-04-22) Issue #41 — `_on_session_start` NullTradingRecorder 폴백 가시성 보강: 콜백 진입부에서 `isinstance(runtime.recorder, NullTradingRecorder)` 검사 → `logger.critical` + `notify_error(stage="session_start.recorder_null", severity="critical")` 1회 방출. ADR-0013 결정 7의 가시성 보강이며 결정 번복·스택 교체 아님 — 별도 ADR 없음. pytest **1068 passed, 4 skipped**.
 
 - **다음 작업**
   - **Phase 2 잔여 (후속 PR)**: KIS 과거 분봉 API 어댑터(별도 PR) · 2~3년 실데이터 수집(운영자 외부 작업, 리포지토리 미포함) · `uv run python scripts/backtest.py --csv-dir ... --from 2023-01-01 --to 2025-12-31` 실행 후 낙폭 절대값 15% 미만 확인 (MDD > -15%). PASS 라벨이 출력돼도 즉시 실전 전환 아님 — Phase 3 모의투자 2주 무사고 운영이 전제.

--- a/src/stock_agent/main.py
+++ b/src/stock_agent/main.py
@@ -395,6 +395,32 @@ def _on_session_start(
     """
 
     def callback() -> None:
+        if isinstance(runtime.recorder, NullTradingRecorder):
+            # Issue #41 — `_default_recorder_factory` 가 SqliteTradingRecorder 조립
+            # 실패 시 남기는 `logger.warning` 은 프로세스 시작 시점에만 남아, 세션
+            # 시작 이후에는 recorder 가 폴백 상태인지 DB 가 비어 있는지 구분이
+            # 불가능하다. 재기동 복원 경로(Issue #33/ADR-0014) 는 폴백 상태에서
+            # `load_open_positions=()` + `has_state=False` → 신규 세션 분기로 빠지며,
+            # 실제 KIS 잔고에 포지션이 남아있으면 첫 reconcile mismatch 까지 이벤트
+            # 손실이 발생한다. 매일 09:00 callback 진입 시 운영자에게 1회 경보를
+            # 방출해 DB 파일·권한 점검을 유도한다. 이후 정상 세션 시작 경로는
+            # 그대로 진행 — Null 폴백이라도 신규 세션 시작 자체는 막지 않는다.
+            logger.critical(
+                "main.session_start.recorder_null — SqliteTradingRecorder 조립 실패 "
+                "폴백 상태. 재기동 복원 불가, 신규 세션으로 시작. DB 파일·권한 확인 필요."
+            )
+            runtime.notifier.notify_error(
+                ErrorEvent(
+                    stage="session_start.recorder_null",
+                    error_class="NullTradingRecorder",
+                    message=(
+                        "영속화 폴백 상태 — SqliteTradingRecorder 조립 실패. "
+                        "재기동 복원 불가, DB 파일·권한 확인 필요."
+                    ),
+                    timestamp=clock(),
+                    severity="critical",
+                )
+            )
         try:
             balance = runtime.kis_client.get_balance()
             starting_capital = min(int(args.starting_capital), int(balance.withdrawable))

--- a/src/stock_agent/monitor/CLAUDE.md
+++ b/src/stock_agent/monitor/CLAUDE.md
@@ -219,6 +219,7 @@ else:
 
 | 콜백 | notifier 호출 | 조건 |
 |---|---|---|
+| `_on_session_start` | `notify_error(stage="session_start.recorder_null", severity="critical")` | `runtime.recorder` 가 `NullTradingRecorder` 인스턴스일 때 1회 (Issue #41, 2026-04-22) |
 | `_on_session_start` | `notify_error(stage="session_start", severity="error")` | 자본 ≤ 0 또는 예외 발생 시 |
 | `_on_step` | `notify_entry(event)` / `notify_exit(event)` | `StepReport.entry_events` / `exit_events` 순회 |
 | `_on_step` | `notify_error(stage="reconcile", severity="critical")` | mismatch 발견 시 1회 dedupe |

--- a/src/stock_agent/storage/CLAUDE.md
+++ b/src/stock_agent/storage/CLAUDE.md
@@ -57,6 +57,16 @@ stock-agent 의 영속화 경계 모듈. `Executor` 가 방출한 `EntryEvent`·
    세션 전체 실패보다 덜 위험하다는 판단. loguru sink 는 유지되므로 사후
    재구성 경로가 완전히 닫히지 않는다.
 
+   **가시성 보강 (Issue #41, 2026-04-22)**: `_on_session_start` 가 매 세션 시작
+   시 `isinstance(runtime.recorder, NullTradingRecorder)` 검사를 수행해, 폴백
+   상태일 때 `logger.critical` + `runtime.notifier.notify_error(stage=
+   "session_start.recorder_null", error_class="NullTradingRecorder",
+   severity="critical")` 를 1회 방출한다. 이후 정상 세션 시작 경로
+   (`get_balance`/`start_session` 또는 `restore_session`) 는 그대로 진행한다.
+   `_default_recorder_factory` 의 `logger.warning` 만으로는 재기동 복원 경로
+   (ADR-0014) 가 Null 폴백에서 신규 세션 분기로 조용히 빠져버리는 silent-failure
+   경로를 충분히 알릴 수 없어 경보 수준을 올렸다.
+
 8. **order_number PK + DTO 확장** — `EntryEvent`·`ExitEvent` 에 `order_number: str`
    필드 추가. `__post_init__` 가드: 빈 문자열·naive timestamp·qty≤0·price≤0 →
    `RuntimeError` (ADR-0003 기조).

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2679,13 +2679,11 @@ class TestOnSessionStartRecorderNull:
         cb()
 
         critical_calls = mock_logger.critical.call_args_list
-        assert (
-            len(critical_calls) >= 1
-        ), f"logger.critical 이 호출되지 않았습니다. calls={critical_calls}"
+        assert_msg = f"logger.critical 이 호출되지 않았습니다. calls={critical_calls}"
+        assert len(critical_calls) >= 1, assert_msg
         messages = [str(c) for c in critical_calls]
-        assert any(
-            "session_start.recorder_null" in m for m in messages
-        ), f"'session_start.recorder_null' 문자열이 logger.critical 에 없음. messages={messages}"
+        has_stage = any("session_start.recorder_null" in m for m in messages)
+        assert has_stage, f"recorder_null 미발견. messages={messages}"
 
     def test_I2_null_recorder_notify_error_stage_session_start_recorder_null(
         self, mocker: Any
@@ -2772,9 +2770,8 @@ class TestOnSessionStartRecorderNull:
             for c in fake_notifier.notify_error.call_args_list
             if c[0][0].stage == "session_start.recorder_null"
         ]
-        assert (
-            len(null_alarm_calls) == 0
-        ), f"NullTradingRecorder 가 아닌데 recorder_null 경보가 발생. calls={null_alarm_calls}"
+        assert_msg = f"recorder_null 경보 불필요 발생. calls={null_alarm_calls}"
+        assert len(null_alarm_calls) == 0, assert_msg
 
     def test_I5_null_recorder_plus_withdrawable_0_notify_error_2회(self, mocker: Any) -> None:
         """I5 — NullTradingRecorder + withdrawable==0 조합.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,7 +101,7 @@ def _make_runtime(
     risk_manager: MagicMock | None = None,
     session_status: SessionStatus | None = None,
     notifier: MagicMock | None = None,
-    recorder: MagicMock | None = None,
+    recorder: MagicMock | TradingRecorder | None = None,
 ) -> Runtime:
     """Runtime 더블 조립 헬퍼.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2629,3 +2629,227 @@ class TestOnSessionStartRestartDetection:
         fake_executor.restore_session.assert_not_called()
         assert ss.started is False
         mock_logger.exception.assert_called_once()
+
+
+# ===========================================================================
+# 그룹 I — _on_session_start recorder_null 경보
+# ===========================================================================
+
+
+class TestOnSessionStartRecorderNull:
+    """_on_session_start 가 NullTradingRecorder 폴백 상태를 critical 경보로 노출하는 계약.
+
+    Issue #41: _default_recorder_factory 가 SqliteTradingRecorder 조립 실패 시
+    NullTradingRecorder 를 주입하지만 세션 시작 시점엔 그 사실이 가려지는 문제 수정.
+    """
+
+    def _make_null_recorder_runtime(
+        self,
+        kis_client: MagicMock | None = None,
+        executor: MagicMock | None = None,
+        notifier: MagicMock | None = None,
+        session_status: SessionStatus | None = None,
+    ) -> Runtime:
+        """NullTradingRecorder 가 주입된 Runtime 더블."""
+        _kis = kis_client or MagicMock(spec=KisClient)
+        _kis.get_balance.return_value = _make_balance(total=2_000_000, withdrawable=1_800_000)
+        _ex = executor or MagicMock(spec=Executor)
+        _notifier = notifier or MagicMock(spec=Notifier)
+        null_recorder = NullTradingRecorder()
+        return _make_runtime(
+            kis_client=_kis,
+            executor=_ex,
+            notifier=_notifier,
+            recorder=null_recorder,
+            session_status=session_status,
+        )
+
+    def test_I1_null_recorder_logger_critical_session_start_recorder_null_포함(
+        self, mocker: Any
+    ) -> None:
+        """I1 — NullTradingRecorder 주입 시 logger.critical 최소 1회,
+        메시지에 "session_start.recorder_null" 포함.
+        """
+        mock_logger = mocker.patch("stock_agent.main.logger")
+        runtime = self._make_null_recorder_runtime()
+        args = _parse_args([])
+        clock = lambda: _kst(9, 0)  # noqa: E731
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        critical_calls = mock_logger.critical.call_args_list
+        assert (
+            len(critical_calls) >= 1
+        ), f"logger.critical 이 호출되지 않았습니다. calls={critical_calls}"
+        messages = [str(c) for c in critical_calls]
+        assert any(
+            "session_start.recorder_null" in m for m in messages
+        ), f"'session_start.recorder_null' 문자열이 logger.critical 에 없음. messages={messages}"
+
+    def test_I2_null_recorder_notify_error_stage_session_start_recorder_null(
+        self, mocker: Any
+    ) -> None:
+        """I2 — NullTradingRecorder 주입 시 notify_error 최소 1회,
+        ErrorEvent.stage == "session_start.recorder_null",
+        error_class == "NullTradingRecorder",
+        severity == "critical",
+        timestamp == clock() 반환값,
+        message 비어있지 않음.
+        """
+        mocker.patch("stock_agent.main.logger")
+        fake_notifier = MagicMock(spec=Notifier)
+        fixed_ts = _kst(9, 0)
+        clock = lambda: fixed_ts  # noqa: E731
+
+        runtime = self._make_null_recorder_runtime(notifier=fake_notifier)
+        args = _parse_args([])
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        # stage="session_start.recorder_null" 인 호출을 추출
+        null_alarm_calls = [
+            c
+            for c in fake_notifier.notify_error.call_args_list
+            if c[0][0].stage == "session_start.recorder_null"
+        ]
+        assert len(null_alarm_calls) >= 1, (
+            f"stage='session_start.recorder_null' notify_error 호출 없음. "
+            f"all_calls={fake_notifier.notify_error.call_args_list}"
+        )
+        event: ErrorEvent = null_alarm_calls[0][0][0]
+        assert event.error_class == "NullTradingRecorder"
+        assert event.severity == "critical"
+        assert event.timestamp == fixed_ts
+        assert event.message != ""
+
+    def test_I3_null_recorder_이후_정상_세션_시작_경로_진행(self, mocker: Any) -> None:
+        """I3 — NullTradingRecorder 경보 발생 후에도 정상 세션 시작 경로가 그대로 진행된다.
+        get_balance 호출 O, withdrawable > 0 이면 executor.start_session 호출 O.
+        """
+        mocker.patch("stock_agent.main.logger")
+        fake_executor = MagicMock(spec=Executor)
+        fake_kis = MagicMock(spec=KisClient)
+        fake_kis.get_balance.return_value = _make_balance(total=2_000_000, withdrawable=1_800_000)
+        ss = SessionStatus(started=False)
+
+        runtime = self._make_null_recorder_runtime(
+            kis_client=fake_kis,
+            executor=fake_executor,
+            session_status=ss,
+        )
+        args = _parse_args(["--starting-capital", "1000000"])
+        clock = lambda: _kst(9, 0)  # noqa: E731
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        fake_kis.get_balance.assert_called_once()
+        fake_executor.start_session.assert_called_once()
+        assert ss.started is True
+
+    def test_I4_null_아닌_recorder_notify_error_recorder_null_미호출(self, mocker: Any) -> None:
+        """I4 — recorder 가 NullTradingRecorder 가 아닌 경우
+        (MagicMock(spec=TradingRecorder)) stage='session_start.recorder_null'
+        인 notify_error 호출이 0회여야 한다.
+        """
+        mocker.patch("stock_agent.main.logger")
+        fake_notifier = MagicMock(spec=Notifier)
+        fake_kis = MagicMock(spec=KisClient)
+        fake_kis.get_balance.return_value = _make_balance(total=2_000_000, withdrawable=1_800_000)
+
+        # _make_runtime 기본값은 MagicMock(spec=TradingRecorder) — NullTradingRecorder 아님
+        runtime = _make_runtime(kis_client=fake_kis, notifier=fake_notifier)
+        args = _parse_args([])
+        clock = lambda: _kst(9, 0)  # noqa: E731
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        null_alarm_calls = [
+            c
+            for c in fake_notifier.notify_error.call_args_list
+            if c[0][0].stage == "session_start.recorder_null"
+        ]
+        assert (
+            len(null_alarm_calls) == 0
+        ), f"NullTradingRecorder 가 아닌데 recorder_null 경보가 발생. calls={null_alarm_calls}"
+
+    def test_I5_null_recorder_plus_withdrawable_0_notify_error_2회(self, mocker: Any) -> None:
+        """I5 — NullTradingRecorder + withdrawable==0 조합.
+        notify_error 가 2회 호출돼야 한다:
+          1회째 stage="session_start.recorder_null" (critical)
+          2회째 stage="session_start" error_class="StartingCapitalError" (error).
+        null 경보가 이후 세션 시작 실패 경보를 삼키면 안 된다.
+        """
+        mocker.patch("stock_agent.main.logger")
+        fake_notifier = MagicMock(spec=Notifier)
+        fake_kis = MagicMock(spec=KisClient)
+        # withdrawable=0 → starting_capital=0 → 조기 return + StartingCapitalError 경보
+        fake_kis.get_balance.return_value = _make_balance(total=2_000_000, withdrawable=0)
+
+        null_recorder = NullTradingRecorder()
+        runtime = _make_runtime(
+            kis_client=fake_kis,
+            notifier=fake_notifier,
+            recorder=null_recorder,
+        )
+        args = _parse_args([])
+        clock = lambda: _kst(9, 0)  # noqa: E731
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        assert fake_notifier.notify_error.call_count == 2, (
+            f"notify_error 2회 기대, 실제={fake_notifier.notify_error.call_count}. "
+            f"calls={fake_notifier.notify_error.call_args_list}"
+        )
+        stages = [c[0][0].stage for c in fake_notifier.notify_error.call_args_list]
+        assert "session_start.recorder_null" in stages
+        assert "session_start" in stages
+
+        # severity 검증
+        calls = fake_notifier.notify_error.call_args_list
+        events_by_stage = {c[0][0].stage: c[0][0] for c in calls}
+        assert events_by_stage["session_start.recorder_null"].severity == "critical"
+        assert events_by_stage["session_start"].error_class == "StartingCapitalError"
+        assert events_by_stage["session_start"].severity == "error"
+
+    def test_I6_null_recorder_plus_get_balance_예외_notify_error_2회(self, mocker: Any) -> None:
+        """I6 — NullTradingRecorder + get_balance ConnectionError 조합.
+        notify_error 가 2회 호출돼야 한다:
+          1회째 stage="session_start.recorder_null" (critical)
+          2회째 stage="session_start" error_class="ConnectionError" (error).
+        null 경보가 예외 경보를 삼키면 안 된다.
+        """
+        mocker.patch("stock_agent.main.logger")
+        fake_notifier = MagicMock(spec=Notifier)
+        fake_kis = MagicMock(spec=KisClient)
+        fake_kis.get_balance.side_effect = ConnectionError("네트워크 오류")
+
+        null_recorder = NullTradingRecorder()
+        runtime = _make_runtime(
+            kis_client=fake_kis,
+            notifier=fake_notifier,
+            recorder=null_recorder,
+        )
+        args = _parse_args([])
+        clock = lambda: _kst(9, 0)  # noqa: E731
+
+        cb = _on_session_start(runtime, args, clock)
+        cb()
+
+        assert fake_notifier.notify_error.call_count == 2, (
+            f"notify_error 2회 기대, 실제={fake_notifier.notify_error.call_count}. "
+            f"calls={fake_notifier.notify_error.call_args_list}"
+        )
+        stages = [c[0][0].stage for c in fake_notifier.notify_error.call_args_list]
+        assert "session_start.recorder_null" in stages
+        assert "session_start" in stages
+
+        calls = fake_notifier.notify_error.call_args_list
+        events_by_stage = {c[0][0].stage: c[0][0] for c in calls}
+        assert events_by_stage["session_start.recorder_null"].severity == "critical"
+        assert events_by_stage["session_start"].error_class == "ConnectionError"
+        assert events_by_stage["session_start"].severity == "error"


### PR DESCRIPTION
Closes #41

## Summary

- `_on_session_start` 콜백 진입부에 `isinstance(runtime.recorder, NullTradingRecorder)` 검사 추가. 폴백 상태일 때 매 세션 시작마다 1회 `logger.critical` + `notifier.notify_error(stage="session_start.recorder_null", error_class="NullTradingRecorder", severity="critical")` 방출.
- 이후 정상 세션 시작 경로(`get_balance` + `start_session` 또는 `restore_session`) 는 그대로 진행. Null 폴백이라도 신규 세션 자체는 막지 않는다.
- ADR-0013 결정 7 가시성 보강이라 새 ADR 불필요.

## 배경

`_default_recorder_factory` 가 `SqliteTradingRecorder` 조립 실패 시 `NullTradingRecorder` 로 폴백하지만, 프로세스 시작 시점의 `logger.warning` 만으로는 세션 시작 이후 recorder 가 Null 폴백인지 실제 DB 가 비어 있는지 구분 불가. 재기동 복원 경로(Issue #33/ADR-0014) 가 Null 폴백에서 조용히 신규 세션 분기로 빠지며, KIS 잔고에 포지션이 남아있으면 첫 reconcile mismatch 까지 이벤트 손실이 발생.

## 변경 파일

- `src/stock_agent/main.py` — `_on_session_start` 콜백에 `isinstance` 검사 + 경보 방출.
- `tests/test_main.py` — `class TestOnSessionStartRecorderNull` 6건 신규 (I1~I6).
- `CLAUDE.md`, `src/stock_agent/storage/CLAUDE.md`, `src/stock_agent/monitor/CLAUDE.md` — 문서 동기화.

## 테스트 계약

| ID | 검증 |
|---|---|
| I1 | `logger.critical` ≥1회 + `"session_start.recorder_null"` 문자열 포함 |
| I2 | `notify_error` stage/error_class/severity/timestamp 계약 |
| I3 | 경보 후 정상 세션 경로 무회귀 (`get_balance` + `start_session` 호출) |
| I4 | Null 아닌 recorder 에서 `recorder_null` 경보 0회 (회귀 방어) |
| I5 | Null + `withdrawable=0` → `notify_error` 2회 독립 발행 (recorder_null + StartingCapitalError) |
| I6 | Null + `ConnectionError` → `notify_error` 2회 독립 발행 (recorder_null + ConnectionError) |

## Test plan

- [x] `uv run pytest -q` → 1068 passed, 4 skipped
- [x] `uv run ruff check src tests scripts` → green
- [x] `uv run black --check src tests scripts` → green
- [x] `uv run pyright src scripts tests` → green
- [x] `uv run pytest tests/test_main.py -k "RecorderNull" -q` → 6/6 passed
- [ ] 모의투자 프로세스 시작 시 `trading.db` 파일 강제 삭제 → 09:00 `_on_session_start` 에서 critical 로그 + 텔레그램 알림 1회 수신 확인 (운영자 외부 검증)