### PR TITLE
fix(strategy): restore_long_position DecimalException → StrategyError 래핑 (#42)

### DIFF
--- a/src/stock_agent/strategy/orb.py
+++ b/src/stock_agent/strategy/orb.py
@@ -385,8 +385,16 @@ class ORBStrategy:
             state.reset(session)
 
         cfg = self._config
-        stop = entry_price * (Decimal("1") - cfg.stop_loss_pct)
-        take = entry_price * (Decimal("1") + cfg.take_profit_pct)
+        try:
+            stop = entry_price * (Decimal("1") - cfg.stop_loss_pct)
+            take = entry_price * (Decimal("1") + cfg.take_profit_pct)
+        except DecimalException as e:
+            # `on_bar` 와 동일 계약 — Decimal 연산 실패만 좁혀 StrategyError 로
+            # 래핑. AttributeError 같은 코드 버그는 의도적으로 propagate.
+            logger.exception(f"ORB restore_long_position Decimal 연산 실패 ({symbol})")
+            raise StrategyError(
+                f"ORB restore_long_position Decimal 연산 실패 ({symbol}): {e}"
+            ) from e
         state.position_state = "long"
         state.entry_price = entry_price
         state.stop_price = stop

--- a/tests/test_strategy_orb.py
+++ b/tests/test_strategy_orb.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import decimal
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
@@ -699,6 +700,74 @@ class TestRestoreLongPosition:
         strategy = ORBStrategy()
         with pytest.raises(RuntimeError, match="entry_price"):
             strategy.restore_long_position(_SYMBOL, Decimal("0"), _now(9, 45))
+
+
+class TestRestoreLongPositionDecimalException:
+    """restore_long_position — Decimal 연산 실패 시 StrategyError 래핑 (Issue #42).
+
+    현재 restore_long_position 에는 on_bar 의 DecimalException → StrategyError
+    래핑 가드(orb.py:182-187)가 없다. 이 클래스는 그 누락을 RED 테스트로 고정해
+    구현 후 GREEN 전환을 강제한다.
+    """
+
+    def test_decimal_exception_stop_계산_StrategyError_래핑(self):
+        """stop = entry_price * (1 - stop_loss_pct) 에서 InvalidOperation 발생 시
+        StrategyError 로 래핑되고 __cause__ 가 DecimalException 서브클래스여야 한다.
+
+        decimal.localcontext 로 Inexact 트랩 + prec=1 설정 후
+        70000 * Decimal("0.985") 계산이 Inexact → InvalidOperation 을 유발한다.
+        """
+        strategy = ORBStrategy()
+        # prec=1 + Inexact 트랩: "70000 * 0.985" 는 Inexact 이므로 InvalidOperation 발생
+        with decimal.localcontext() as ctx:
+            ctx.prec = 1
+            ctx.traps[decimal.Inexact] = True
+            with pytest.raises(StrategyError) as exc_info:
+                strategy.restore_long_position(_SYMBOL, Decimal("70000"), _now(9, 45))
+
+        err = exc_info.value
+        # __cause__ 가 DecimalException 계열이어야 한다
+        assert isinstance(err.__cause__, decimal.DecimalException)
+        # 오류 메시지에 symbol 이 포함되어야 한다
+        assert _SYMBOL in str(err)
+
+    def test_decimal_exception_take_계산_StrategyError_래핑(self):
+        """take = entry_price * (1 + take_profit_pct) 계산에서도 동일하게 래핑된다.
+
+        stop_loss_pct 를 정확히 계산 가능한 Decimal("0") 으로 강제 불가
+        (StrategyConfig 검증이 0 을 거부하므로) — 대신 prec=1 + Inexact 트랩으로
+        두 곱셈 중 하나에서 트리거한다. 어느 쪽이든 StrategyError 이면 충분.
+        """
+        strategy = ORBStrategy()
+        with decimal.localcontext() as ctx:
+            ctx.prec = 1
+            ctx.traps[decimal.Inexact] = True
+            with pytest.raises(StrategyError) as exc_info:
+                strategy.restore_long_position(_SYMBOL, Decimal("68500"), _now(10, 0))
+
+        err = exc_info.value
+        assert isinstance(err.__cause__, decimal.DecimalException)
+        assert _SYMBOL in str(err)
+
+    def test_runtime_error_경로_변경_없음_symbol_포맷(self):
+        """DecimalException 래핑 추가 후에도 symbol 포맷 오류는 여전히 RuntimeError."""
+        strategy = ORBStrategy()
+        with decimal.localcontext() as ctx:
+            ctx.prec = 1
+            ctx.traps[decimal.Inexact] = True
+            # symbol 검증은 Decimal 연산 이전에 수행되므로 RuntimeError 전파
+            with pytest.raises(RuntimeError, match="symbol"):
+                strategy.restore_long_position("1234", Decimal("70000"), _now(9, 45))
+
+    def test_runtime_error_경로_변경_없음_naive_ts(self):
+        """DecimalException 래핑 추가 후에도 naive entry_ts 는 여전히 RuntimeError."""
+        strategy = ORBStrategy()
+        naive_ts = datetime(2026, 4, 20, 9, 45)  # tzinfo=None
+        with decimal.localcontext() as ctx:
+            ctx.prec = 1
+            ctx.traps[decimal.Inexact] = True
+            with pytest.raises(RuntimeError, match="entry_ts"):
+                strategy.restore_long_position(_SYMBOL, Decimal("70000"), naive_ts)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 배경

Issue #42. `ORBStrategy.on_bar` 는 `DecimalException` 을 `StrategyError` 로 래핑하고 `__cause__` 를 보존하지만 (`src/stock_agent/strategy/orb.py:182-187`), `restore_long_position` 은 stop/take 재계산의 `DecimalException` 을 raw 전파했다. PR #38 silent-failure-hunter HIGH 지적.

PR #38 에서 `Executor.restore_session` 원자성 롤백이 들어가 치명적 부분 상태는 없지만, 운영자 트리아지 시 `ExecutorError(__cause__=DecimalException)` 가 잡혀 "왜 Decimal 연산이 깨졌지?" 를 추적하려면 traceback 을 타고 내려가야 했다. 예외 계층 일관성 회복이 목적.

## 변경

- `src/stock_agent/strategy/orb.py:387-397` — `restore_long_position` 의 Decimal 연산 2라인을 `try/except DecimalException` 으로 감싸 `StrategyError` 로 래핑. `logger.exception` 동반, `raise ... from e` 로 `__cause__` 보존. `on_bar` 와 동일 계약.
- `tests/test_strategy_orb.py` — `TestRestoreLongPositionDecimalException` 클래스 신규, 4 케이스:
  - stop 계산 경로 Inexact 트랩 트리거 → `StrategyError` + `__cause__` 검증
  - take 계산 경로 동일 검증
  - symbol 포맷 오류는 Decimal 연산 이전 가드 → `RuntimeError` 불변 회귀
  - naive `entry_ts` 도 `RuntimeError` 불변 회귀
- `decimal.localcontext(prec=1)` + `Inexact` 트랩으로 순수 stdlib 트리거. 외부 목 없음.

## 범위 제외

- `Executor.restore_session` 롤백 로직은 PR #38 에서 완료. 본 PR 은 StrategyError 래핑 일관성만.
- ADR 불필요 — 결정 번복·스택 교체 아님. `on_bar` 계약을 동일 모듈 이웃 메서드로 확장한 수정.

## 검증

- `uv run pytest` — 전체 green (strategy 64/64 포함)
- `uv run ruff check src scripts tests` — clean
- `uv run ruff format --check` · `uv run black --check` — clean
- `uv run pyright src scripts tests` — 0 errors

## 관련

- Closes #42
- ADR-0014 (세션 재기동 상태 복원 경로) 결정 5 — `restore_long_position` 동작
- PR #38 리뷰 HIGH (silent-failure-hunter Q7)