### PR TITLE
refactor(data,backtest): PR #46 후속 정리 — H1·H3·M1·M2·M3 (#48)

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -239,14 +239,22 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         r=sum(result.rejected_counts.values()),
         p=result.post_slippage_rejections,
         m=_format_pct(result.metrics.max_drawdown_pct),
-        v=_verdict_label(result.metrics.max_drawdown_pct),
+        v=_verdict_label(
+            result.metrics.max_drawdown_pct,
+            daily_equity_len=len(result.daily_equity),
+            symbol_count=len(symbols),
+        ),
     )
 
 
 def _render_markdown(result: BacktestResult, context: _ReportContext) -> str:
     """`BacktestResult` → 사람이 읽는 Markdown 리포트."""
     metrics = result.metrics
-    verdict = _verdict_label(metrics.max_drawdown_pct)
+    verdict = _verdict_label(
+        metrics.max_drawdown_pct,
+        daily_equity_len=len(result.daily_equity),
+        symbol_count=len(context.symbols),
+    )
     lines: list[str] = []
 
     lines.append("# ORB 백테스트 리포트")
@@ -370,7 +378,12 @@ def _write_trades_csv(trades: tuple[TradeRecord, ...], path: Path) -> None:
             )
 
 
-def _verdict_label(mdd: Decimal) -> str:
+def _verdict_label(
+    mdd: Decimal,
+    *,
+    daily_equity_len: int | None = None,
+    symbol_count: int | None = None,
+) -> str:
     """`mdd > -0.15` (낙폭 절대값 15% 미만) 이면 PASS.
 
     MDD 는 음수 또는 0 (`BacktestMetrics.max_drawdown_pct` 계약). 임계값
@@ -380,8 +393,24 @@ def _verdict_label(mdd: Decimal) -> str:
 
     의도: plan.md Phase 2 Verification "MDD 낙폭 15% 이내" — "낙폭 제한
     기준" 이므로 낙폭이 더 깊을수록 FAIL 이 되어야 한다.
+
+    Caveat (ADR-0017 결정 3·4 코드 반영):
+    - `daily_equity_len < 240` → "표본 240 미만" 주의 추가.
+    - `symbol_count == 1` → "단일 종목" 주의 추가.
+    PASS 인 경우에만 caveat 를 합쳐 `"PASS (참고용 — ...)"` 로 반환하고,
+    FAIL 은 caveat 무관 `"FAIL"` 만 반환. 두 인자 모두 `None` 이면 기존
+    단순 이진 라벨 동작 (backward compat).
     """
-    return "PASS" if mdd > _MDD_PASS_THRESHOLD else "FAIL"
+    if mdd <= _MDD_PASS_THRESHOLD:
+        return "FAIL"
+    caveats: list[str] = []
+    if daily_equity_len is not None and daily_equity_len < 240:
+        caveats.append("표본 240 미만")
+    if symbol_count is not None and symbol_count == 1:
+        caveats.append("단일 종목")
+    if not caveats:
+        return "PASS"
+    return f"PASS (참고용 — {', '.join(caveats)})"
 
 
 def _format_pct(value: Decimal) -> str:

--- a/src/stock_agent/data/CLAUDE.md
+++ b/src/stock_agent/data/CLAUDE.md
@@ -62,6 +62,10 @@ YAML 로더, 실시간 분봉 소스를 한 자리에 모아 상위 레이어
   - **페이지네이션**: 120건 역방향 커서 + 1분 감소. 종료 조건 `len(rows) < 120` 또는 `min_time <= "090000"`.
   - **레이트 리밋 재시도**: `EGW00201` 응답 → `sleep(61.0)` 후 재시도, 최대 3회.
   - **SQLite 캐시**: 별도 파일 `data/minute_bars.db` (기본 경로). `data/stock_agent.db` 일봉 캐시·`data/trading.db` 원장과 독립된 생명주기. 스키마 v1: `minute_bars(symbol, bar_time, open, high, low, close, volume, PRIMARY KEY(symbol, bar_time))` + `schema_version`. 가격은 `TEXT`로 저장해 `Decimal` 정밀도 보존.
+  - **bar_time 계약**: **KST aware ISO8601**, `second=0, microsecond=0` 강제 (분 경계). `_parse_row` 가 KST 부여 + 초·마이크로초 절삭 수행. `_date_cached` 의 `BETWEEN '...T00:00:00+09:00' AND '...T23:59:59+09:00'` 쿼리가 이 계약에 의존 — 외부 도구가 같은 테이블에 다른 tz 로 쓰면 캐시 판정이 어긋남 (M1 명문화, Issue #48).
+  - **오늘 자 읽기·쓰기 모두 skip**: `_collect_symbol_bars` 가 `is_today` 분기를 **독립 분기**로 분리. 이전 실행에서 어떤 경로로든 오늘 자 행이 DB 에 있어도 장중 미확정 데이터가 사용되지 않도록 쓰기뿐 아니라 읽기도 스킵 (H1, Issue #48).
+  - **운영 경보**: `_fetch_day` 가 `rows` 비어있지 않은데 `page_bars` 가 빈 페이지를 만나면 `(symbol, day)` 당 최초 1 회 `logger.error` 방출. KIS 응답 스키마 변경·수신 오염 징후 포착 용 (M2, Issue #48).
+  - **단일 스레드 전용 (ADR-0008)**: `sqlite3.Connection` 기본값 `check_same_thread=True` 유지. `_lock` 은 `_ensure_kis` 지연 초기화만 보호 — 다른 스레드에서 DB 호출 경로 진입 시 `sqlite3.ProgrammingError` 폭파. 백테스트 엔진 병렬화 요구 발생 시 별도 ADR 로 재평가 (H3 명문화, Issue #48).
   - **KIS 서버 보관 한도**: **최대 1년 분봉**. 2~3년 백테스트 요구는 본 어댑터로 해결 불가. Issue #5 후속으로 별도 데이터 소스(외부 유료 데이터, 직접 수집 등) 분리 평가 필요. Phase 2 PASS 검증은 CSV 어댑터(`minute_csv.py`)로 수행한다.
   - **`BarLoader` Protocol 준수**: `backtest/loader.py`의 `BarLoader` Protocol — `stream(start, end, symbols)` 계약 충족. 동일 인자 재호출 시 매번 새 Iterable 반환.
   - **CLI 스위치**: `scripts/backtest.py`·`scripts/sensitivity.py`에 `--loader={csv,kis}` 옵션 추가 (default `"csv"`). `--csv-dir`는 `--loader=csv`일 때만 필수.

--- a/src/stock_agent/data/kis_minute_bars.py
+++ b/src/stock_agent/data/kis_minute_bars.py
@@ -23,10 +23,24 @@
   캐시 초기화 가능.
 - 가격은 `TEXT` 로 저장해 `Decimal` 정밀도 보존 (`historical.py` · `storage/db.py` 와
   동일 기조).
-- `bar_time` 은 ISO8601 with tz (`"2026-04-22T09:31:00+09:00"`).
+- `bar_time` 계약: **KST aware ISO8601** (`"2026-04-22T09:31:00+09:00"`),
+  `second=0, microsecond=0` 강제 (분 경계). `_parse_row` 가 KST 부여 + 초/마이크로초
+  절삭을 수행하므로 이 모듈이 직접 쓴 값은 계약을 지킨다. `_date_cached` 의
+  `BETWEEN '...T00:00:00+09:00' AND '...T23:59:59+09:00'` 쿼리는 이 계약에
+  의존 — 외부 도구가 같은 테이블에 다른 tz 문자열로 쓰면 캐시 판정이 어긋난다.
 - 캐시 hit 판정은 `(symbol, 날짜)` 단위. 해당 날짜 bar 가 한 건이라도 있으면
-  API 재호출 생략. `date == clock().date()` 인 "오늘" 자는 항상 재조회 —
-  실시간 분봉은 `realtime.py` 경로와 별개로 장중에는 미확정.
+  API 재호출 생략. `date == clock().date()` 인 "오늘" 자는 항상 재조회 (**쓰기·읽기
+  모두 skip** — 이전 실행에서 어떤 경로로든 오늘 자 행이 DB 에 있어도 장중
+  미확정 데이터가 사용되지 않도록 분기 자체를 분리한다). 실시간 분봉은
+  `realtime.py` 경로와 별개로 장중에는 미확정.
+
+동시성 (ADR-0008 단일 프로세스 전용)
+- 이 어댑터는 **단일 스레드 전용**. `sqlite3.Connection` 은 `check_same_thread=True`
+  기본값을 사용하므로 다른 스레드에서 `stream`/`_fetch_day`/`_write_bars_to_db`/
+  `_read_day_from_db`/`_date_cached` 를 호출하면 `sqlite3.ProgrammingError` 로 폭파한다.
+- `_lock` 은 `_ensure_kis` 의 지연 초기화 race 만 보호한다 — 단일 스레드 전제
+  하에서는 DB 호출을 전역 락으로 감쌀 필요가 없다. 백테스트 엔진 병렬화
+  요구가 생기면 별도 ADR 로 전환 재평가.
 
 에러 정책 (`historical.py` / `minute_csv.py` 와 동일 기조)
 - `RuntimeError` 는 전파 — 호출자 계약 위반 (`start > end`, 빈 `symbols`,
@@ -286,7 +300,9 @@ class KisMinuteBarLoader:
         """한 심볼의 `[start, end]` 구간 bar 를 수집. 시간 오름차순 반환.
 
         날짜는 `end → start` 역방향 순회. 각 날짜마다:
-        - `date == today` → 항상 API 재호출 (캐시 쓰지도 않음).
+        - `date == today` → 항상 API 재호출. DB 쓰기 **와 읽기 모두 skip**
+          (stale bar 방어 — 이전 실행에서 어떤 경로로든 오늘 자 행이 이미
+          DB 에 있어도 장중 미확정 데이터가 사용되지 않도록 분기 자체를 분리).
         - DB 에 해당 날짜 bar 존재 → DB 재사용.
         - 그 외 → API 호출 + DB 쓰기.
         """
@@ -295,14 +311,15 @@ class KisMinuteBarLoader:
 
         current = end
         while current >= start:
-            is_today = current == today
-            if is_today or not self._date_cached(symbol, current):
+            if current == today:
                 day_bars = self._fetch_day(symbol, current)
-                if not is_today:
-                    self._write_bars_to_db(day_bars)
                 collected.extend(day_bars)
-            else:
+            elif self._date_cached(symbol, current):
                 collected.extend(self._read_day_from_db(symbol, current))
+            else:
+                day_bars = self._fetch_day(symbol, current)
+                self._write_bars_to_db(day_bars)
+                collected.extend(day_bars)
             current -= timedelta(days=1)
 
         # 날짜별 수집이라 bar_time 오름차순으로 재정렬.
@@ -385,6 +402,11 @@ class KisMinuteBarLoader:
         """단일 날짜의 전체 bar 를 120 건 역방향 커서 페이지네이션으로 수집.
 
         빈 응답은 주말·공휴일 또는 KIS 서버 보관 경계 밖으로 간주해 빈 리스트 반환.
+
+        운영 경보 (M2): `rows` 는 비어있지 않은데 `page_bars` 가 비는 (전원
+        파싱 실패) 상황은 KIS 응답 스키마 변경 또는 수신 오염 징후라 빈 응답
+        (정상 공휴일) 과 구별되어야 한다. `(symbol, day)` 단위로 최초 1 회만
+        `logger.error` 방출해 로그 폭주 방지.
         """
         kis = self._ensure_kis()
         date_str = day.strftime("%Y%m%d")
@@ -392,6 +414,7 @@ class KisMinuteBarLoader:
         collected: list[MinuteBar] = []
         seen: set[datetime] = set()
         is_first_page = True
+        malformed_warned = False
 
         while True:
             if not is_first_page and self._throttle_s > 0:
@@ -415,6 +438,15 @@ class KisMinuteBarLoader:
                     continue
                 seen.add(bar.bar_time)
                 page_bars.append(bar)
+
+            if not page_bars and not malformed_warned:
+                logger.error(
+                    "KIS 분봉 페이지 전원 파싱 실패 — symbol={s} date={d} rows={n}",
+                    s=symbol,
+                    d=date_str,
+                    n=len(rows),
+                )
+                malformed_warned = True
 
             collected.extend(page_bars)
 

--- a/tests/test_backtest_cli.py
+++ b/tests/test_backtest_cli.py
@@ -315,6 +315,48 @@ class TestVerdictLabel:
         """_MDD_PASS_THRESHOLD 상수가 Decimal('-0.15') 임을 확인."""
         assert Decimal("-0.15") == _MDD_PASS_THRESHOLD
 
+    # --- M3: daily_equity_len / symbol_count 확장 시그니처 테스트 ---
+
+    def test_표본_240_미만_PASS_참고용_표본_240_미만(self):
+        """daily_equity_len=239 → caveat '표본 240 미만' 포함."""
+        result = _verdict_label(Decimal("-0.10"), daily_equity_len=239, symbol_count=3)
+        assert result == "PASS (참고용 — 표본 240 미만)", (
+            f"표본 239일 때 caveat 포함 라벨 기대, 실제={result!r}"
+        )
+
+    def test_단일_종목_PASS_참고용_단일_종목(self):
+        """symbol_count=1 → caveat '단일 종목' 포함."""
+        result = _verdict_label(Decimal("-0.10"), daily_equity_len=240, symbol_count=1)
+        assert result == "PASS (참고용 — 단일 종목)", (
+            f"단일 종목일 때 caveat 포함 라벨 기대, 실제={result!r}"
+        )
+
+    def test_표본_240_미만_AND_단일_종목_두_caveat_모두_포함(self):
+        """daily_equity_len=100, symbol_count=1 → caveat 2개 모두 포함, 순서 고정."""
+        result = _verdict_label(Decimal("-0.10"), daily_equity_len=100, symbol_count=1)
+        assert result == "PASS (참고용 — 표본 240 미만, 단일 종목)", (
+            f"두 caveat 모두 포함, 순서='표본 240 미만' → '단일 종목' 기대, 실제={result!r}"
+        )
+
+    def test_표본_240_이상_다중_종목_caveat_없음(self):
+        """daily_equity_len=240, symbol_count=3 → caveat 없음 → 'PASS'."""
+        result = _verdict_label(Decimal("-0.10"), daily_equity_len=240, symbol_count=3)
+        assert result == "PASS", (
+            f"표본 충분 + 다중 종목이면 caveat 없는 'PASS' 기대, 실제={result!r}"
+        )
+
+    def test_FAIL_이면_caveat_붙지_않음(self):
+        """mdd <= -0.15 이면 daily_equity_len/symbol_count 관계없이 'FAIL'."""
+        result = _verdict_label(Decimal("-0.20"), daily_equity_len=100, symbol_count=1)
+        assert result == "FAIL", f"FAIL 판정에는 caveat 를 붙이지 않아야 함, 실제={result!r}"
+
+    def test_backward_compat_인자_없으면_PASS(self):
+        """기존 _verdict_label(mdd) 단독 호출 — backward compat 확인."""
+        result = _verdict_label(Decimal("-0.10"))
+        assert result == "PASS", (
+            f"기존 단독 호출은 backward compat 으로 'PASS' 반환, 실제={result!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. _format_pct / _format_decimal
@@ -389,10 +431,15 @@ class TestRenderMarkdown:
             assert label in md, f"레이블 '{label}' 미포함"
 
     def test_PASS_verdict(self):
-        """MDD > -0.15 (낙폭 절대값 15% 미만) → '**PASS**' 가 포함된다."""
+        """MDD > -0.15 (낙폭 절대값 15% 미만) → '**PASS' 로 시작하는 verdict 가 포함된다.
+
+        caveat 유무(표본 수·종목 수)에 따라 라벨이 '**PASS**' 또는
+        '**PASS (참고용 — ...)**' 형태로 달라질 수 있으므로 '**PASS' 포함 여부만 검증.
+        caveat 동작 자체는 TestVerdictLabel 케이스가 커버한다.
+        """
         metrics = _make_metrics(max_drawdown_pct=Decimal("-0.10"))
         md = _render_markdown(_make_result(metrics=metrics), self._ctx())
-        assert "**PASS**" in md
+        assert "**PASS" in md and "**FAIL**" not in md
 
     def test_FAIL_verdict(self):
         """MDD <= -0.15 → '**FAIL**' 가 포함된다."""

--- a/tests/test_backtest_cli.py
+++ b/tests/test_backtest_cli.py
@@ -320,42 +320,32 @@ class TestVerdictLabel:
     def test_표본_240_미만_PASS_참고용_표본_240_미만(self):
         """daily_equity_len=239 → caveat '표본 240 미만' 포함."""
         result = _verdict_label(Decimal("-0.10"), daily_equity_len=239, symbol_count=3)
-        assert result == "PASS (참고용 — 표본 240 미만)", (
-            f"표본 239일 때 caveat 포함 라벨 기대, 실제={result!r}"
-        )
+        assert result == "PASS (참고용 — 표본 240 미만)"
 
     def test_단일_종목_PASS_참고용_단일_종목(self):
         """symbol_count=1 → caveat '단일 종목' 포함."""
         result = _verdict_label(Decimal("-0.10"), daily_equity_len=240, symbol_count=1)
-        assert result == "PASS (참고용 — 단일 종목)", (
-            f"단일 종목일 때 caveat 포함 라벨 기대, 실제={result!r}"
-        )
+        assert result == "PASS (참고용 — 단일 종목)"
 
     def test_표본_240_미만_AND_단일_종목_두_caveat_모두_포함(self):
         """daily_equity_len=100, symbol_count=1 → caveat 2개 모두 포함, 순서 고정."""
         result = _verdict_label(Decimal("-0.10"), daily_equity_len=100, symbol_count=1)
-        assert result == "PASS (참고용 — 표본 240 미만, 단일 종목)", (
-            f"두 caveat 모두 포함, 순서='표본 240 미만' → '단일 종목' 기대, 실제={result!r}"
-        )
+        assert result == "PASS (참고용 — 표본 240 미만, 단일 종목)"
 
     def test_표본_240_이상_다중_종목_caveat_없음(self):
         """daily_equity_len=240, symbol_count=3 → caveat 없음 → 'PASS'."""
         result = _verdict_label(Decimal("-0.10"), daily_equity_len=240, symbol_count=3)
-        assert result == "PASS", (
-            f"표본 충분 + 다중 종목이면 caveat 없는 'PASS' 기대, 실제={result!r}"
-        )
+        assert result == "PASS"
 
     def test_FAIL_이면_caveat_붙지_않음(self):
         """mdd <= -0.15 이면 daily_equity_len/symbol_count 관계없이 'FAIL'."""
         result = _verdict_label(Decimal("-0.20"), daily_equity_len=100, symbol_count=1)
-        assert result == "FAIL", f"FAIL 판정에는 caveat 를 붙이지 않아야 함, 실제={result!r}"
+        assert result == "FAIL"
 
     def test_backward_compat_인자_없으면_PASS(self):
         """기존 _verdict_label(mdd) 단독 호출 — backward compat 확인."""
         result = _verdict_label(Decimal("-0.10"))
-        assert result == "PASS", (
-            f"기존 단독 호출은 backward compat 으로 'PASS' 반환, 실제={result!r}"
-        )
+        assert result == "PASS"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kis_minute_bar_loader.py
+++ b/tests/test_kis_minute_bar_loader.py
@@ -1149,6 +1149,81 @@ class TestCacheTodayAlwaysRefetches:
         fake_kis.fetch.assert_called()
         loader.close()
 
+    def test_오늘_날짜_DB선삽입값이_아닌_API기반값_반환(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_kis,
+        pykis_factory,
+        guard_patch,
+        mock_sleep,
+        tmp_path: Path,
+    ) -> None:
+        """오늘 자 bar 는 DB 에 무엇이 있든 API 응답값을 반환 — DB 읽기 skip 증명.
+
+        H1: is_today 분기에서 DB 읽기 경로(else 분기)로 빠지면 DB 선삽입값(71200)이
+        반환되어 이 테스트가 실패한다. API 기반값(70100)이 반환돼야 GREEN.
+        """
+        KisMinuteBarLoader, _ = _import_loader()
+        settings = _make_settings_with_live_keys(monkeypatch)
+
+        db_path = tmp_path / "test.db"
+        # DB 에 오늘 자 bar 선삽입 — close=71200 (구분 가능한 "stale" 값)
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS minute_bars (
+                symbol TEXT,
+                bar_time TEXT,
+                open TEXT,
+                high TEXT,
+                low TEXT,
+                close TEXT,
+                volume INTEGER,
+                PRIMARY KEY (symbol, bar_time)
+            );
+            CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY);
+            INSERT OR IGNORE INTO schema_version VALUES (1);
+        """)
+        bar_time_str = f"{_TODAY.isoformat()}T09:31:00+09:00"
+        conn.execute(
+            "INSERT OR REPLACE INTO minute_bars VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (_SYMBOL, bar_time_str, "71000", "71500", "70800", "71200", 1234),
+        )
+        conn.commit()
+        conn.close()
+
+        # API 응답은 DB 와 다른 값 — close=70100 (기본 _make_output2_row 기본값과 다르게 설정)
+        fake_kis.fetch.return_value = _make_api_response(
+            [
+                _make_output2_row(
+                    _TODAY,
+                    9,
+                    31,
+                    oprc="70000",
+                    hgpr="70500",
+                    lwpr="69800",
+                    prpr="70100",
+                    vol="999",
+                ),
+            ]
+        )
+
+        loader = KisMinuteBarLoader(
+            settings,
+            pykis_factory=pykis_factory,
+            clock=_fixed_clock(_kst(_TODAY, 10, 0)),
+            cache_db_path=db_path,
+            sleep=mock_sleep,
+        )
+        bars = list(loader.stream(_TODAY, _TODAY, (_SYMBOL,)))
+        loader.close()
+
+        assert len(bars) >= 1, "bar 가 1건 이상 반환돼야 한다"
+        # DB 선삽입값(71200)이 아니라 API 응답값(70100)이어야 함 — DB 읽기 skip 증명
+        assert bars[0].close == Decimal("70100"), (
+            f"오늘 자 bar 는 DB 읽기를 skip 하고 API 기반값(70100)을 반환해야 한다 "
+            f"(실제 반환값={bars[0].close})"
+        )
+
 
 # ===========================================================================
 # TestSchemaV1Init — 스키마 초기화 검증
@@ -1307,6 +1382,154 @@ class TestErrorWrapping:
 
         assert exc_info.value.__cause__ is original_error
         loader.close()
+
+
+# ===========================================================================
+# TestMalformedPageWarning — output2 rows 있지만 전원 parse 실패 시 logger.error 경보
+# ===========================================================================
+
+
+class TestMalformedPageWarning:
+    """M2: _fetch_day 내에서 rows ≥1 이지만 page_bars 가 빈 경우 logger.error 방출 검증.
+
+    dedupe 규칙: 동일 (symbol, day) 조합의 _fetch_day 한 번당 최초 1회만 방출.
+    """
+
+    @pytest.fixture
+    def _loguru_errors(self):
+        """loguru ERROR 레벨 메시지 캡처 — 프로젝트 관례(test_rate_limiter.py 패턴) 재사용."""
+        from loguru import logger as _logger
+
+        captured: list[dict] = []
+
+        def _sink(message) -> None:  # type: ignore[no-untyped-def]
+            record = message.record
+            captured.append({"level": record["level"].name, "message": record["message"]})
+
+        handler_id = _logger.add(_sink, level="ERROR", format="{message}")
+        try:
+            yield captured
+        finally:
+            _logger.remove(handler_id)
+
+    def test_rows_전원_malformed_logger_error_1회_심볼_날짜_포함(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_kis,
+        pykis_factory,
+        guard_patch,
+        mock_sleep,
+        tmp_path: Path,
+        _loguru_errors,
+    ) -> None:
+        """rows 3건 모두 stck_oprc='' malformed → page_bars 비고 rows ≥1 → logger.error 1회.
+
+        에러 메시지에 symbol 과 date(날짜) 정보가 포함되어야 한다.
+        """
+        KisMinuteBarLoader, _ = _import_loader()
+        settings = _make_settings_with_live_keys(monkeypatch)
+
+        # stck_oprc="" → _parse_decimal 이 ValueError → _parse_row 가 None 반환
+        malformed_rows = [_make_output2_row(_YESTERDAY, 9, 31 + i, oprc="") for i in range(3)]
+        fake_kis.fetch.return_value = _make_api_response(malformed_rows)
+
+        loader = KisMinuteBarLoader(
+            settings,
+            pykis_factory=pykis_factory,
+            clock=_fixed_clock(_kst(_TODAY, 10, 0)),
+            cache_db_path=tmp_path / "test.db",
+            sleep=mock_sleep,
+        )
+        list(loader.stream(_YESTERDAY, _YESTERDAY, (_SYMBOL,)))
+        loader.close()
+
+        errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
+        assert len(errors) == 1, (
+            f"rows ≥1 이고 page_bars 비면 logger.error 를 정확히 1회 방출해야 한다 "
+            f"(실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
+        )
+        # 에러 메시지에 symbol 과 날짜 정보가 포함돼야 한다
+        msg = errors[0]["message"]
+        assert _SYMBOL in msg, f"에러 메시지에 symbol={_SYMBOL!r} 포함 필수 (실제: {msg!r})"
+        assert _YESTERDAY.strftime("%Y%m%d") in msg or str(_YESTERDAY) in msg, (
+            f"에러 메시지에 날짜={_YESTERDAY} 정보 포함 필수 (실제: {msg!r})"
+        )
+
+    def test_rows_0건_정상_공휴일_logger_error_없음(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_kis,
+        pykis_factory,
+        guard_patch,
+        mock_sleep,
+        tmp_path: Path,
+        _loguru_errors,
+    ) -> None:
+        """rows 0건(정상 주말·공휴일 경계) → logger.error 미방출 — 빈 응답과 구별."""
+        KisMinuteBarLoader, _ = _import_loader()
+        settings = _make_settings_with_live_keys(monkeypatch)
+
+        # 빈 output2 — 주말/공휴일 정상 케이스
+        fake_kis.fetch.return_value = _make_api_response([])
+
+        loader = KisMinuteBarLoader(
+            settings,
+            pykis_factory=pykis_factory,
+            clock=_fixed_clock(_kst(_TODAY, 10, 0)),
+            cache_db_path=tmp_path / "test.db",
+            sleep=mock_sleep,
+        )
+        list(loader.stream(_YESTERDAY, _YESTERDAY, (_SYMBOL,)))
+        loader.close()
+
+        errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
+        assert len(errors) == 0, (
+            f"rows=0 (빈 응답) 은 logger.error 를 방출하면 안 됨 "
+            f"(실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
+        )
+
+    def test_2페이지_모두_malformed_logger_error_1회만_dedupe(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_kis,
+        pykis_factory,
+        guard_patch,
+        mock_sleep,
+        tmp_path: Path,
+        _loguru_errors,
+    ) -> None:
+        """2페이지 모두 rows ≥1 + 전원 malformed → 같은 (symbol, day) 쌍 → logger.error 1회만.
+
+        dedupe: _fetch_day 한 번당 동일 (symbol, day) 조합은 최초 페이지 1회만 방출.
+        첫 응답 120건(전원 malformed), 두 번째 응답 3건(전원 malformed).
+        """
+        KisMinuteBarLoader, _ = _import_loader()
+        settings = _make_settings_with_live_keys(monkeypatch)
+
+        # 첫 페이지: 120건 전원 malformed (페이지네이션이 다음 페이지로 계속 진행하게 len=120)
+        first_malformed = [_make_output2_row(_YESTERDAY, 9, 31, oprc="") for _ in range(120)]
+        # 두 번째 페이지: 3건 전원 malformed (len < 120 → 종료)
+        second_malformed = [_make_output2_row(_YESTERDAY, 9, 28 + i, oprc="") for i in range(3)]
+        fake_kis.fetch.side_effect = [
+            _make_api_response(first_malformed),
+            _make_api_response(second_malformed),
+        ]
+
+        loader = KisMinuteBarLoader(
+            settings,
+            pykis_factory=pykis_factory,
+            clock=_fixed_clock(_kst(_TODAY, 10, 0)),
+            cache_db_path=tmp_path / "test.db",
+            sleep=mock_sleep,
+        )
+        list(loader.stream(_YESTERDAY, _YESTERDAY, (_SYMBOL,)))
+        loader.close()
+
+        errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
+        assert len(errors) == 1, (
+            f"동일 (symbol, day) 에 대해 _fetch_day 내 logger.error 는 1회만 방출해야 한다 "
+            f"(dedupe, 실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
+        )
 
 
 # ===========================================================================

--- a/tests/test_kis_minute_bar_loader.py
+++ b/tests/test_kis_minute_bar_loader.py
@@ -1217,12 +1217,9 @@ class TestCacheTodayAlwaysRefetches:
         bars = list(loader.stream(_TODAY, _TODAY, (_SYMBOL,)))
         loader.close()
 
-        assert len(bars) >= 1, "bar 가 1건 이상 반환돼야 한다"
+        assert len(bars) >= 1
         # DB 선삽입값(71200)이 아니라 API 응답값(70100)이어야 함 — DB 읽기 skip 증명
-        assert bars[0].close == Decimal("70100"), (
-            f"오늘 자 bar 는 DB 읽기를 skip 하고 API 기반값(70100)을 반환해야 한다 "
-            f"(실제 반환값={bars[0].close})"
-        )
+        assert bars[0].close == Decimal("70100")
 
 
 # ===========================================================================
@@ -1444,16 +1441,11 @@ class TestMalformedPageWarning:
         loader.close()
 
         errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
-        assert len(errors) == 1, (
-            f"rows ≥1 이고 page_bars 비면 logger.error 를 정확히 1회 방출해야 한다 "
-            f"(실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
-        )
+        assert len(errors) == 1
         # 에러 메시지에 symbol 과 날짜 정보가 포함돼야 한다
         msg = errors[0]["message"]
-        assert _SYMBOL in msg, f"에러 메시지에 symbol={_SYMBOL!r} 포함 필수 (실제: {msg!r})"
-        assert _YESTERDAY.strftime("%Y%m%d") in msg or str(_YESTERDAY) in msg, (
-            f"에러 메시지에 날짜={_YESTERDAY} 정보 포함 필수 (실제: {msg!r})"
-        )
+        assert _SYMBOL in msg
+        assert _YESTERDAY.strftime("%Y%m%d") in msg or str(_YESTERDAY) in msg
 
     def test_rows_0건_정상_공휴일_logger_error_없음(
         self,
@@ -1483,10 +1475,7 @@ class TestMalformedPageWarning:
         loader.close()
 
         errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
-        assert len(errors) == 0, (
-            f"rows=0 (빈 응답) 은 logger.error 를 방출하면 안 됨 "
-            f"(실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
-        )
+        assert len(errors) == 0
 
     def test_2페이지_모두_malformed_logger_error_1회만_dedupe(
         self,
@@ -1526,10 +1515,7 @@ class TestMalformedPageWarning:
         loader.close()
 
         errors = [m for m in _loguru_errors if m["level"] == "ERROR"]
-        assert len(errors) == 1, (
-            f"동일 (symbol, day) 에 대해 _fetch_day 내 logger.error 는 1회만 방출해야 한다 "
-            f"(dedupe, 실제 {len(errors)}회, messages={[m['message'] for m in errors]})"
-        )
+        assert len(errors) == 1
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Issue #48 — PR #46 (KIS 과거 분봉 어댑터) code-review 잔여 5 건을 단일 PR 로 해결.

- **H1** `_collect_symbol_bars` 오늘 자 분기 분리 — 읽기·쓰기 모두 skip 의도 명시.
- **H3** 모듈 docstring 에 단일 스레드 전용 (ADR-0008) 명문화.
- **M1** `bar_time` KST aware ISO8601 + `second=0, microsecond=0` 계약 명시.
- **M2** `_fetch_day` 파싱 전원 실패 페이지 `(symbol, day)` 당 1 회 `logger.error` 경보.
- **M3** `scripts/backtest.py` `_verdict_label` 확장 — `daily_equity_len < 240` / `symbol_count == 1` PASS 에 caveat 접미 (ADR-0017 결정 3·4 코드 반영).

## 변경 요약

### `src/stock_agent/data/kis_minute_bars.py`

| 항목 | 변경 |
|---|---|
| H1 | `_collect_symbol_bars` `is_today or not cached` 단락평가 → `if / elif / else` 3 분기 명시 |
| H3 | 모듈 docstring 동시성 섹션 신설 (단일 스레드 + `_lock` 역할) |
| M1 | 모듈 docstring `bar_time` 계약 확장 |
| M2 | `_fetch_day` dedupe 플래그 + `logger.error` 1 회 방출 |

### `scripts/backtest.py`

- `_verdict_label(mdd, *, daily_equity_len=None, symbol_count=None)` 시그니처 확장 (backward compat).
- `_render_markdown` · `_run_pipeline` logger 호출부 caveat 인자 주입.

### 테스트

- `tests/test_kis_minute_bar_loader.py`:
  - `TestCacheTodayAlwaysRefetches` +1 (H1 반환값 기준 stale 방어 검증).
  - 신규 `TestMalformedPageWarning` 3 건 (전원 malformed·빈 응답·2 페이지 dedupe).
- `tests/test_backtest_cli.py`:
  - `TestVerdictLabel` +6 (caveat 조합·FAIL 시 미부착·backward compat).
  - `TestRenderMarkdown::test_PASS_verdict` assertion 완화 (PASS 분기만 검증).

### 문서

- `src/stock_agent/data/CLAUDE.md` 에 H1·H3·M1·M2 계약 4 줄 추가.

## 검증

| 항목 | 결과 |
|---|---|
| pytest | 1135 passed, 4 skipped |
| ruff check / format --check | 0 에러 |
| black --check | 0 파일 reformat |
| pyright (src scripts tests) | 0 errors, 0 warnings |

모두 `src scripts tests` 범위, CI 파이프라인과 동일.

## Test plan

- [x] pytest 전체 그린
- [x] CI 4 종 로컬 그린
- [x] 신규 테스트 RED → GREEN 전환 확인
- [x] 기존 `test_PASS_verdict` 회귀 수정 반영
- [x] ADR-0017 코드 반영 확인 (240 영업일 미만 · 단일 종목 caveat)

## 주의

- ADR 신규 작성 없음 — H1·H3·M1·M2 는 기존 ADR-0008·0016 결정 명문화, M3 은 ADR-0017 결정의 코드 반영. 결정 번복·스택 교체 아님.
- `test_PASS_verdict` 회귀는 M3 의 caveat 확장으로 정확일치가 깨진 것. caveat 동작 자체는 신규 `TestVerdictLabel` 6 건이 커버하므로 assertion 완화로 해소.

## Refs

- Issue #48
- PR #46 (KIS 과거 분봉 어댑터 + ADR-0016/0017)
- ADR-0008 (단일 프로세스 전용), ADR-0016 (KIS 어댑터 캐시), ADR-0017 (Phase 2 기준 완화)

Closes #48