### PR TITLE
feat(scripts): Step C 유동성 랭킹·서브셋 빌더 + --universe-yaml (#76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,11 +225,11 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
 - **복구 로드맵 진행 상황**:
   - **Step A — 민감도 그리드** (2026-04-25): **FAIL**. 28/32 조합 게이트 0 통과, 최저 MDD -42.08%. 상세는 `docs/runbooks/step_a_result_2026-04-25.md`.
   - **Step B — 비용 가정 재검정** (Issue #75, 2026-04-29 완료): 3 거래일 (04-27·04-29·04-30) 장중 실 호가 331,530 샘플 수집 → 전체 중앙값 스프레드 0.1305% (현행 가정 0.1% 대비 1.3×, 사전 기준 0.05~0.2% 내). **ADR-0006 슬리피지 0.1% 유지 결정**. `backtest/costs.py` 변경 없음. 새 ADR 없음. Step A 재실행 불필요. 분석: `docs/runbooks/step_b_spread_analysis.md`.
-  - **Step C** — 유니버스 유동성 필터 (pykrx 거래대금 상위 N).
-  - **Step D** — 전략 파라미터 구조 변경 (OR 윈도·force_close_at·재진입·일 N 진입).
+  - **Step C — 유니버스 유동성 필터 인프라 완료 (2026-04-30, Issue #76)**: `scripts/build_liquidity_ranking.py` (pykrx 영업일 bulk 호출 → `avg_value_krw` 랭킹 CSV) + `scripts/build_universe_subset.py` (랭킹 CSV → 서브셋 YAML) 신설. `scripts/backtest.py`·`scripts/sensitivity.py` 에 `--universe-yaml PATH` 플래그 추가 (default `config/universe.yaml`, backward-compat). 테스트 신규 44건. **운영자 실행 대기**: 12개월 윈도 랭킹 산출 → `universe_top50.yaml`·`universe_top100.yaml` 생성 → `--loader=kis --universe-yaml` 로 백테스트 2회 → ADR-0019 세 게이트 판정 → 결과 runbook 작성 (별도 PR).
+  - **Step D** — 전략 파라미터 구조 변경 (OR 윈도·force_close_at·재진입·일 N 진입). Step C 통과 서브셋 부재 시 진행.
   - **Step E** — 전략 교체 (VWAP mean-reversion / opening gap reversal / pre-market pullback). A~D 전원 실패 전제.
 - **Phase 3 진입 금지 (ADR-0019)**: 게이트 통과 전까지 `main.py` 모의투자 무중단 운영 계획 전면 보류. `execution/`·`main.py`·`monitor/`·`storage/` 코드 산출물은 보존 — 복구 후 그대로 재사용.
-- **테스트 카운트**: pytest **1364 passed, 4 skipped** (Issue #82 incremental flush 후 기준).
+- **테스트 카운트**: pytest **1408 passed, 4 skipped** (Step C 인프라 PR 기준 — 신규 44건: `test_build_liquidity_ranking.py` 16 + `test_build_universe_subset.py` 16 + `test_backtest_cli.py` +6 + `test_sensitivity_cli.py` +6).
 - **운영자 close 대기 Issue**: #51 (Phase 2 PASS 판정 FAIL → 복구 로드맵으로 대체) · #52 (`KisMinuteBarLoader` 파싱 실패 대응, 운영자 `scripts/debug_kis_minute.py` 실행 후 댓글) · #63 (공휴일 캘린더 가드, 백필 재실행으로 `date_mismatch` 0 확인 후 댓글) · #71 (장시간 hang 방지, 2026-04-24 백필 완주 확인 — 운영자 댓글만 잔여).
 
 상세한 Phase 별 산출물·결정·테스트 카운트 변화·Issue 대응 이력은 [docs/phase-history.md](./docs/phase-history.md) 참조.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ KOSPI 200 대형주를 대상으로 Opening Range Breakout(ORB) 전략을 자동
 
 **ADR-0019 복구 로드맵 Step A FAIL (2026-04-25)**. 32 조합 민감도 그리드 실행 (28/32 완료 — 4 조합 미실행, 결과 뒤집힐 가능성 0% 로 즉시 종결). 세 게이트(MDD > -15% · 승률×손익비 > 1.0 · 샤프 > 0) 동시 통과 조합 **0 / 28**. 최고 수익률 -40.91%, 전 조합 샤프 음수.
 
-**Step B 완료 (2026-04-29)** — 3 거래일 장중 실 호가 수집 (331,530 샘플). 전체 중앙값 스프레드 0.1305% — 현행 가정 0.1% 대비 1.3× 이지만 사전 기준(0.05~0.2%) 내. **ADR-0006 슬리피지 가정 0.1% 유지 결정. `costs.py` 변경 없음.** 다음 단계: Step C (유니버스 유동성 필터). 상세 설계와 각 Phase의 PASS 기준, 비용·위험 분석은 [`plan.md`](./plan.md)에 있습니다.
+**Step B 완료 (2026-04-29)** — 3 거래일 장중 실 호가 수집 (331,530 샘플). 전체 중앙값 스프레드 0.1305% — 현행 가정 0.1% 대비 1.3× 이지만 사전 기준(0.05~0.2%) 내. **ADR-0006 슬리피지 가정 0.1% 유지 결정. `costs.py` 변경 없음.**
+
+**Step C 인프라 완료 (2026-04-30, Issue #76)** — `scripts/build_liquidity_ranking.py` + `scripts/build_universe_subset.py` 신설. `scripts/backtest.py`·`scripts/sensitivity.py` 에 `--universe-yaml PATH` 플래그 추가. 운영자 실행(랭킹 산출 → 서브셋 YAML → 백테스트 2회 → 게이트 판정)은 별도 PR. 상세 설계와 각 Phase의 PASS 기준, 비용·위험 분석은 [`plan.md`](./plan.md)에 있습니다.
 
 **Phase 3 착수 전제 통과** (2026-04-21). 실전 시세 전용 APP_KEY 3종 발급·IP 화이트리스트 등록·평일 장중 `healthcheck.py` 4종 그린(WebSocket 체결 수신 OK) 완료.
 
@@ -98,7 +100,7 @@ KOSPI 200 대형주를 대상으로 Opening Range Breakout(ORB) 전략을 자동
 
 ## 디렉토리 구조
 
-현재 존재하는 파일 (Phase 2 여덟 번째 산출물 완료 기준):
+현재 존재하는 파일 (Phase 2 Step C 인프라 완료 기준):
 
 ```text
 stock-agent/
@@ -182,7 +184,9 @@ stock-agent/
     ├── backtest.py                 # 단일 런 백테스트 CLI
     ├── sensitivity.py              # 파라미터 민감도 32 조합 그리드 (--resume 지정 시 조합 단위 incremental flush, freeze 내성)
     ├── backfill_minute_bars.py     # KIS 과거 분봉 캐시 일괄 적재 CLI
-    └── collect_spread_samples.py   # KIS 호가 스프레드 스냅샷 수집 CLI (Step B 인프라, JSONL 출력)
+    ├── collect_spread_samples.py   # KIS 호가 스프레드 스냅샷 수집 CLI (Step B 인프라, JSONL 출력)
+    ├── build_liquidity_ranking.py  # KOSPI 200 유동성 랭킹 산출 CLI (Step C 인프라, CSV 출력)
+    └── build_universe_subset.py    # 유동성 랭킹 CSV → KOSPI 200 서브셋 YAML 생성 (Step C 보조)
 ```
 
 미착수 모듈의 청사진은 [`plan.md`](./plan.md)의 디렉토리 구조 섹션 참조.

--- a/plan.md
+++ b/plan.md
@@ -381,6 +381,41 @@ pytest **245 → 324 → 384 → 464 → 477 → 539 → 542건 green** (기존 
 
 **→ Step C (유니버스 유동성 필터)** 로 이행.
 
+### Step C 인프라 완료 — 운영자 실행 대기 (2026-04-30, Issue #76)
+
+코드 산출물 4건 완료. 운영자 실행(별도 PR)은 미완료.
+
+**신규 스크립트**:
+
+- `scripts/build_liquidity_ranking.py`: KOSPI 200 유동성 랭킹 산출.
+  - `pykrx get_market_ohlcv_by_ticker(yyyymmdd, market="KOSPI")` 영업일 bulk 호출
+  - `YamlBusinessDayCalendar` 영업일 필터 (주말·공휴일 skip)
+  - 출력 CSV 컬럼: `symbol,avg_value_krw,daily_return_std,sample_days,rank_value`
+  - 50% 이상 영업일 실패 시 `RuntimeError("excessive_failures: ...")` fail-fast
+  - exit code: `0` 정상 / `2` 입력·설정 오류 / `3` I/O 오류
+  - 사용 예: `uv run python scripts/build_liquidity_ranking.py --start 2024-04-22 --end 2025-04-21 --universe-yaml config/universe.yaml --output-csv data/liquidity_ranking.csv`
+
+- `scripts/build_universe_subset.py`: 유동성 랭킹 CSV → KOSPI 200 서브셋 YAML 생성.
+  - `rank_value <= top_n` 종목 추출. 출력 스키마: `as_of_date / source / tickers` (`config/universe.yaml` 정본과 동일)
+  - 작성 직후 `load_kospi200_universe(output)` 자체 검증. `rank_value` 1..N 연속 검증 (음수·중복·결손 거부)
+  - ADR-0004 수동 관리 정책 계승: 자동 git 커밋 아님 — 운영자 검토 후 `git add` 책임
+  - 사용 예: `uv run python scripts/build_universe_subset.py --ranking-csv data/liquidity_ranking.csv --top-n 50 --output-yaml config/universe_top50.yaml --source "Step C — Top 50 by avg_value_krw, window=2024-04-22..2025-04-21" --as-of 2025-04-21`
+
+**기존 CLI 확장** (`scripts/backtest.py`, `scripts/sensitivity.py`):
+- `--universe-yaml PATH` 플래그 추가 (default `config/universe.yaml`, backward-compat)
+- `_resolve_symbols(raw, universe_yaml=None)` 시그니처 확장 — path 주어지면 `load_kospi200_universe(path)` 호출
+- 효과: `--loader=kis --universe-yaml config/universe_top50.yaml` 로 서브셋 백테스트 실행 가능
+
+**테스트**: 신규 44건 (`test_build_liquidity_ranking.py` 16 + `test_build_universe_subset.py` 16 + `test_backtest_cli.py` +6 + `test_sensitivity_cli.py` +6). 4종 정적 검사 GREEN.
+
+**다음 단계 (별도 PR — 운영자 실행)**:
+1. `uv run python scripts/build_liquidity_ranking.py --start 2024-04-22 --end 2025-04-21 --universe-yaml config/universe.yaml --output-csv data/liquidity_ranking.csv`
+2. `uv run python scripts/build_universe_subset.py --ranking-csv data/liquidity_ranking.csv --top-n 50 --output-yaml config/universe_top50.yaml ...` (top-100 도 동일)
+3. `uv run python scripts/backtest.py --loader=kis --universe-yaml config/universe_top50.yaml --from 2025-04-22 --to 2026-04-21` (top-100 도 동일)
+4. ADR-0019 세 게이트 판정 (MDD > -15%, 승률 × 손익비 > 1.0, 샤프 > 0)
+5. `docs/runbooks/step_c_liquidity_filter_YYYY-MM-DD.md` 작성
+6. 통과 서브셋 없으면 Step D 진행
+
 ---
 
 ## Phase 3 진행 요약 (2026-04-21 기준)

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -115,7 +115,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--symbols",
         type=str,
         default="",
-        help="쉼표 구분 종목 코드 (미지정 시 config/universe.yaml 전체 사용).",
+        help="쉼표 구분 종목 코드 (미지정 시 --universe-yaml 전체 사용).",
+    )
+    parser.add_argument(
+        "--universe-yaml",
+        type=Path,
+        default=Path("config/universe.yaml"),
+        help=(
+            "유니버스 YAML 경로. --symbols 미지정 시 이 YAML 의 tickers 를 사용 "
+            "(서브셋 백테스트 시 config/universe_top50.yaml 등 지정)."
+        ),
     )
     parser.add_argument(
         "--starting-capital",
@@ -148,20 +157,27 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return args
 
 
-def _resolve_symbols(raw: str) -> tuple[str, ...]:
+def _resolve_symbols(raw: str, universe_yaml: Path | None = None) -> tuple[str, ...]:
     """`--symbols` 인자 해석 — 빈 값이면 유니버스 YAML 전체.
 
     `scripts/sensitivity.py:_resolve_symbols` 와 동일 계약. 공용 헬퍼로
     승격은 YAGNI (현재 소비자 2개).
+
+    `universe_yaml=None` 이면 backward-compat 으로 `load_kospi200_universe()` 를
+    인자 없이 호출 (기존 단인자 호출 경로 보존). path 가 주어지면 해당 path 를
+    `load_kospi200_universe(path)` 에 전달.
     """
     if raw.strip():
         parts = tuple(s.strip() for s in raw.split(",") if s.strip())
         return parts
-    universe = load_kospi200_universe()
+    if universe_yaml is None:
+        universe = load_kospi200_universe()
+    else:
+        universe = load_kospi200_universe(universe_yaml)
     if not universe.tickers:
         raise RuntimeError(
-            "config/universe.yaml 이 비어있습니다 — --symbols 로 명시하거나 "
-            "유니버스 YAML 을 갱신하세요."
+            f"유니버스 YAML 이 비어있습니다 — --symbols 로 명시하거나 "
+            f"YAML 을 갱신하세요 (path={universe_yaml or 'config/universe.yaml'})."
         )
     return universe.tickers
 
@@ -198,7 +214,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     예외 → exit code 매핑에 집중한다 (sensitivity 와 동일 기조). `KisMinuteBarLoader`
     는 SQLite 커넥션을 닫아야 하므로 `try/finally` 로 `close()` 호출.
     """
-    symbols = _resolve_symbols(args.symbols)
+    symbols = _resolve_symbols(args.symbols, args.universe_yaml)
     loader = _build_loader(args)
     config = BacktestConfig(starting_capital_krw=args.starting_capital)
     engine = BacktestEngine(config)

--- a/scripts/build_liquidity_ranking.py
+++ b/scripts/build_liquidity_ranking.py
@@ -1,0 +1,260 @@
+"""유동성 랭킹 산출 CLI — Step C (Issue #76, ADR-0019).
+
+ADR-0019 Phase 2 복구 로드맵 Step C. KOSPI 200 199 종목의 12개월 평균 거래대금과
+일간 수익률 표준편차를 산출해 거래대금 상위 N (Top 50/100) 서브셋 구성을 위한
+입력을 만든다. Look-ahead bias 방지를 위해 산출 윈도는 백테스트 구간 시작 직전
+12개월로 운영자가 지정한다.
+
+사용 예시:
+
+```
+uv run python scripts/build_liquidity_ranking.py \
+  --start 2024-04-22 --end 2025-04-21 \
+  --universe-yaml config/universe.yaml \
+  --output-csv data/liquidity_ranking.csv
+```
+
+CSV 컬럼 (헤더 포함, 정확한 순서):
+
+- `symbol`: 6자리 문자열
+- `avg_value_krw`: int (mean(거래대금) 반올림)
+- `daily_return_std`: float (std(daily_return), 표본 표준편차 ddof=1)
+- `sample_days`: int (해당 종목이 데이터로 잡힌 영업일 수)
+- `rank_value`: int (1=최대 거래대금, 동률 시 symbol 오름차순)
+
+exit code
+- 0: 정상.
+- 2: 입력·설정 오류 (`start > end`, 빈 영업일, 50% 이상 영업일 실패) — 재시도 무의미.
+- 3: I/O 오류 — 재시도 가치 있음.
+
+제약
+- 실 pykrx 네트워크 호출 — KRX 정보데이터시스템 응답 (외부 인증·키 무관).
+- 영업일 캘린더는 `config/holidays.yaml` (`YamlBusinessDayCalendar`).
+- 본 스크립트는 단발 ETL — 결과 CSV 는 운영자가 git 추적 외부(`data/`) 에서 검토 후
+  `scripts/build_universe_subset.py` 로 yaml 산출에 투입한다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import sys
+from collections.abc import Callable
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from stock_agent.data import (
+    BusinessDayCalendar,
+    UniverseLoadError,
+    YamlBusinessDayCalendar,
+    load_kospi200_universe,
+)
+
+_EXIT_OK = 0
+_EXIT_INPUT_ERROR = 2
+_EXIT_IO_ERROR = 3
+
+_FAILURE_RATIO_THRESHOLD = 0.5
+
+_CSV_HEADER = ("symbol", "avg_value_krw", "daily_return_std", "sample_days", "rank_value")
+
+
+def _default_pykrx_factory() -> Any:
+    """기본 pykrx 팩토리 — 지연 import (`historical.py` 와 동일 패턴)."""
+    from pykrx import stock as _stock  # noqa: PLC0415
+
+    class _PykrxNs:
+        stock = _stock
+
+    return _PykrxNs()
+
+
+def _enumerate_business_days(start: date, end: date, calendar: BusinessDayCalendar) -> list[date]:
+    days: list[date] = []
+    cur = start
+    one_day = timedelta(days=1)
+    while cur <= end:
+        if calendar.is_business_day(cur):
+            days.append(cur)
+        cur += one_day
+    return days
+
+
+def _row_value(df: Any, sym: str, col: str) -> Any:
+    """DataFrame 의 (symbol, col) 셀을 안전하게 가져온다."""
+    return df.loc[sym, col]
+
+
+def build_ranking(
+    *,
+    start: date,
+    end: date,
+    universe_yaml: Path,
+    output_csv: Path,
+    pykrx_factory: Callable[[], Any] | None = None,
+    calendar: BusinessDayCalendar | None = None,
+) -> None:
+    """KOSPI bulk 일봉 거래대금 + 종가를 영업일별 호출해 종목별 평균·표준편차 CSV 출력."""
+    if start > end:
+        raise RuntimeError(f"start > end: {start} > {end}")
+
+    universe = load_kospi200_universe(universe_yaml)
+    universe_set = set(universe.tickers)
+
+    cal = calendar if calendar is not None else YamlBusinessDayCalendar()
+    business_days = _enumerate_business_days(start, end, cal)
+    if not business_days:
+        raise RuntimeError(f"no business days in range {start.isoformat()}..{end.isoformat()}")
+
+    factory = pykrx_factory if pykrx_factory is not None else _default_pykrx_factory
+    pykrx = factory()
+
+    # symbol -> {date -> (close, value)}
+    daily_data: dict[str, dict[date, tuple[float, int]]] = {}
+    failed_days = 0
+
+    for d in business_days:
+        yyyymmdd = d.strftime("%Y%m%d")
+        try:
+            df = pykrx.stock.get_market_ohlcv_by_ticker(yyyymmdd, market="KOSPI")
+        except Exception:
+            logger.exception(f"pykrx 호출 실패 — date={d.isoformat()}")
+            failed_days += 1
+            continue
+
+        if df is None or len(df) == 0:
+            logger.warning(f"pykrx 빈 응답 — date={d.isoformat()}")
+            failed_days += 1
+            continue
+
+        try:
+            present_idx = list(df.index)
+        except Exception:
+            logger.exception(f"DataFrame index 추출 실패 — date={d.isoformat()}")
+            failed_days += 1
+            continue
+
+        for sym in present_idx:
+            if not isinstance(sym, str) or sym not in universe_set:
+                continue
+            try:
+                close = float(_row_value(df, sym, "종가"))
+                value = int(_row_value(df, sym, "거래대금"))
+            except (KeyError, ValueError, TypeError):
+                logger.warning(f"row 파싱 실패 — date={d.isoformat()} symbol={sym}")
+                continue
+            daily_data.setdefault(sym, {})[d] = (close, value)
+
+    n_business = len(business_days)
+    if n_business > 0 and failed_days / n_business > _FAILURE_RATIO_THRESHOLD:
+        raise RuntimeError(
+            f"excessive_failures: {failed_days}/{n_business} business days returned empty"
+        )
+
+    rows: list[tuple[str, int, float, int]] = []
+    for sym in universe.tickers:
+        sym_data = daily_data.get(sym)
+        if not sym_data:
+            logger.warning(f"symbol {sym} — 모든 영업일에서 데이터 누락, CSV 제외")
+            continue
+        ordered_days = sorted(sym_data.keys())
+        sample_days = len(ordered_days)
+        values = [sym_data[d][1] for d in ordered_days]
+        avg_value_krw = int(round(sum(values) / sample_days))
+
+        returns: list[float] = []
+        for i in range(1, sample_days):
+            prev_close = sym_data[ordered_days[i - 1]][0]
+            cur_close = sym_data[ordered_days[i]][0]
+            if prev_close > 0:
+                returns.append(cur_close / prev_close - 1.0)
+
+        std_val = statistics.stdev(returns) if len(returns) >= 2 else 0.0
+
+        rows.append((sym, avg_value_krw, std_val, sample_days))
+
+    rows.sort(key=lambda r: (-r[1], r[0]))
+
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with output_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(_CSV_HEADER)
+        for rank, (sym, avg, std_val, sample) in enumerate(rows, start=1):
+            writer.writerow([sym, avg, _format_std(std_val), sample, rank])
+
+    logger.info(
+        "liquidity_ranking.done symbols={n} business_days={d} failed_days={f} output={p}",
+        n=len(rows),
+        d=n_business,
+        f=failed_days,
+        p=str(output_csv),
+    )
+
+
+def _format_std(value: float) -> str:
+    """`daily_return_std` 직렬화 — 정밀도 보존 + 0 은 '0' 으로."""
+    if value == 0.0:
+        return "0"
+    return repr(value)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="KOSPI 200 유동성 랭킹 산출 (Step C, ADR-0019)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--start",
+        type=date.fromisoformat,
+        required=True,
+        help="윈도 시작 (YYYY-MM-DD, 경계 포함). 백테스트 구간 시작 직전 12개월 권장.",
+    )
+    parser.add_argument(
+        "--end",
+        type=date.fromisoformat,
+        required=True,
+        help="윈도 종료 (YYYY-MM-DD, 경계 포함).",
+    )
+    parser.add_argument(
+        "--universe-yaml",
+        type=Path,
+        default=Path("config/universe.yaml"),
+        help="KOSPI 200 유니버스 YAML 경로.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=Path("data/liquidity_ranking.csv"),
+        help="유동성 랭킹 CSV 출력 경로.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        build_ranking(
+            start=args.start,
+            end=args.end,
+            universe_yaml=args.universe_yaml,
+            output_csv=args.output_csv,
+        )
+    except UniverseLoadError as e:
+        logger.error(f"universe 로드 실패: {e}")
+        return _EXIT_INPUT_ERROR
+    except RuntimeError as e:
+        logger.error(f"입력·설정 오류: {e}")
+        return _EXIT_INPUT_ERROR
+    except OSError as e:
+        logger.error(f"I/O 오류: {e}")
+        return _EXIT_IO_ERROR
+
+    return _EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_universe_subset.py
+++ b/scripts/build_universe_subset.py
@@ -1,0 +1,203 @@
+"""유동성 랭킹 기반 KOSPI 200 서브셋 yaml 생성 CLI — Step C (Issue #76, ADR-0019).
+
+`scripts/build_liquidity_ranking.py` 가 산출한 `data/liquidity_ranking.csv` 를
+입력으로 받아 `rank_value <= top_n` 인 종목만 추출해 KOSPI 200 서브셋 yaml 을
+만든다. 출력 yaml schema 는 `config/universe.yaml` 정본과 동일 — 작성 직후
+`load_kospi200_universe` 로 자체 검증한다.
+
+ADR-0004 (KOSPI 200 수동 관리) 정책 유지: 본 스크립트는 yaml 을 자동 작성하지만,
+운영자가 결과를 검토 후 git add 하는 단계에서 책임을 진다 (자동 git 커밋 아님).
+
+사용 예시:
+
+```
+uv run python scripts/build_universe_subset.py \
+  --ranking-csv data/liquidity_ranking.csv \
+  --top-n 50 \
+  --output-yaml config/universe_top50.yaml \
+  --source "Step C — Top 50 by avg_value_krw, window=2024-04-22..2025-04-21" \
+  --as-of 2025-04-21
+```
+
+exit code (build_liquidity_ranking 와 동일)
+- 0: 정상.
+- 2: 입력·설정 오류 (`top_n<=0`, CSV 헤더·rank 검증 실패 등) — 재시도 무의미.
+- 3: I/O 오류 — 재시도 가치 있음.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+from loguru import logger
+
+from stock_agent.data import load_kospi200_universe
+
+_EXIT_OK = 0
+_EXIT_INPUT_ERROR = 2
+_EXIT_IO_ERROR = 3
+
+_REQUIRED_COLUMNS = ("symbol", "rank_value")
+
+
+def _read_ranking_rows(ranking_csv: Path) -> list[dict[str, str]]:
+    """ranking CSV 를 읽어 dict list 반환. 헤더 누락 시 RuntimeError."""
+    with ranking_csv.open(encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise RuntimeError(f"ranking CSV 가 헤더를 갖지 않습니다 (path={ranking_csv})")
+        missing = [c for c in _REQUIRED_COLUMNS if c not in reader.fieldnames]
+        if missing:
+            raise RuntimeError(
+                f"ranking CSV 에 필수 컬럼이 없습니다: {missing} "
+                f"(path={ranking_csv}, fields={list(reader.fieldnames)})"
+            )
+        return list(reader)
+
+
+def _validate_ranks(rows: list[dict[str, str]], path: Path) -> dict[int, str]:
+    """rank_value 가 정확히 1..N contiguous, 음수·중복·결손 모두 거부.
+
+    반환: {rank: symbol} 매핑.
+    """
+    if not rows:
+        raise RuntimeError(f"ranking CSV row 가 비어있습니다 (path={path})")
+
+    rank_to_sym: dict[int, str] = {}
+    for row in rows:
+        sym = row.get("symbol", "")
+        rank_str = row.get("rank_value", "")
+        try:
+            rank = int(rank_str)
+        except (ValueError, TypeError) as e:
+            raise RuntimeError(
+                f"rank_value 파싱 실패: {rank_str!r} (symbol={sym}, path={path})"
+            ) from e
+        if rank in rank_to_sym:
+            raise RuntimeError(
+                f"rank_value 중복: {rank} (symbols={rank_to_sym[rank]!r}, {sym!r}, path={path})"
+            )
+        rank_to_sym[rank] = sym
+
+    expected = set(range(1, len(rows) + 1))
+    actual = set(rank_to_sym.keys())
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise RuntimeError(
+            f"rank_value 가 1..{len(rows)} contiguous 아님 — "
+            f"missing={missing}, extra={extra} (path={path})"
+        )
+    return rank_to_sym
+
+
+def build_subset(
+    *,
+    ranking_csv: Path,
+    top_n: int,
+    output_yaml: Path,
+    source: str,
+    as_of: date,
+) -> None:
+    """ranking CSV 에서 rank_value 1..top_n 인 종목으로 서브셋 yaml 작성."""
+    if top_n <= 0:
+        raise RuntimeError(f"top_n 은 1 이상이어야 합니다: {top_n}")
+
+    rows = _read_ranking_rows(ranking_csv)
+    rank_to_sym = _validate_ranks(rows, ranking_csv)
+
+    if top_n > len(rows):
+        raise RuntimeError(
+            f"top_n={top_n} 이 CSV row 수({len(rows)}) 를 초과합니다 (path={ranking_csv})"
+        )
+
+    selected = sorted(rank_to_sym[r] for r in range(1, top_n + 1))
+
+    payload: dict[str, Any] = {
+        "as_of_date": as_of.isoformat(),
+        "source": source,
+        "tickers": selected,
+    }
+
+    output_yaml.parent.mkdir(parents=True, exist_ok=True)
+    with output_yaml.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(payload, f, allow_unicode=True, sort_keys=False)
+
+    universe = load_kospi200_universe(output_yaml)
+    logger.info(
+        "universe_subset.done top_n={n} written={p} verified_tickers={t}",
+        n=top_n,
+        p=str(output_yaml),
+        t=len(universe.tickers),
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="유동성 랭킹 기반 KOSPI 200 서브셋 yaml 생성 (Step C, ADR-0019)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--ranking-csv",
+        type=Path,
+        required=True,
+        help="유동성 랭킹 CSV 경로 (build_liquidity_ranking.py 산출물).",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        required=True,
+        help="추출할 상위 N (rank_value 1..N).",
+    )
+    parser.add_argument(
+        "--output-yaml",
+        type=Path,
+        required=True,
+        help="서브셋 universe yaml 출력 경로.",
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        required=True,
+        help="universe.yaml source 필드 — 갱신 근거 추적용 자유 문자열.",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=date.fromisoformat,
+        required=True,
+        help="universe.yaml as_of_date (YYYY-MM-DD).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        build_subset(
+            ranking_csv=args.ranking_csv,
+            top_n=args.top_n,
+            output_yaml=args.output_yaml,
+            source=args.source,
+            as_of=args.as_of,
+        )
+    except RuntimeError as e:
+        logger.error(f"입력·설정 오류: {e}")
+        return _EXIT_INPUT_ERROR
+    except FileNotFoundError as e:
+        logger.error(f"입력 파일 없음: {e}")
+        return _EXIT_INPUT_ERROR
+    except OSError as e:
+        logger.error(f"I/O 오류: {e}")
+        return _EXIT_IO_ERROR
+
+    return _EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sensitivity.py
+++ b/scripts/sensitivity.py
@@ -123,7 +123,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--symbols",
         type=str,
         default="",
-        help="쉼표 구분 종목 코드 (미지정 시 config/universe.yaml 전체 사용).",
+        help="쉼표 구분 종목 코드 (미지정 시 --universe-yaml 전체 사용).",
+    )
+    parser.add_argument(
+        "--universe-yaml",
+        type=Path,
+        default=Path("config/universe.yaml"),
+        help=(
+            "유니버스 YAML 경로. --symbols 미지정 시 이 YAML 의 tickers 를 사용 "
+            "(서브셋 민감도 시 config/universe_top50.yaml 등 지정)."
+        ),
     )
     parser.add_argument(
         "--starting-capital",
@@ -218,21 +227,27 @@ def _resolve_workers(raw: int | None) -> int:
     return raw
 
 
-def _resolve_symbols(raw: str) -> tuple[str, ...]:
+def _resolve_symbols(raw: str, universe_yaml: Path | None = None) -> tuple[str, ...]:
     """`--symbols` 인자 해석 — 빈 값이면 유니버스 YAML 전체.
 
     `raw` 에 쉼표만 들어오는 극단 케이스는 `raw.strip()` 이 falsy 로 평가되어
     자동으로 유니버스 로드 분기로 빠진다 (별도 RuntimeError 불필요 — 현재
     분기 구조상 도달 불가능한 방어 코드는 두지 않는다).
+
+    `universe_yaml=None` 이면 backward-compat 으로 `load_kospi200_universe()` 를
+    인자 없이 호출. path 가 주어지면 해당 path 를 전달 (Step C 서브셋 지원).
     """
     if raw.strip():
         parts = tuple(s.strip() for s in raw.split(",") if s.strip())
         return parts
-    universe = load_kospi200_universe()
+    if universe_yaml is None:
+        universe = load_kospi200_universe()
+    else:
+        universe = load_kospi200_universe(universe_yaml)
     if not universe.tickers:
         raise RuntimeError(
-            "config/universe.yaml 이 비어있습니다 — --symbols 로 명시하거나 "
-            "유니버스 YAML 을 갱신하세요."
+            f"유니버스 YAML 이 비어있습니다 — --symbols 로 명시하거나 "
+            f"YAML 을 갱신하세요 (path={universe_yaml or 'config/universe.yaml'})."
         )
     return universe.tickers
 
@@ -261,7 +276,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     엔진 함수에 주입해 조합 1개 종료 시점마다 `args.output_csv` 에 atomic
     append. 직렬·병렬 양쪽 동일. 메인 프로세스 단일 writer.
     """
-    symbols = _resolve_symbols(args.symbols)
+    symbols = _resolve_symbols(args.symbols, args.universe_yaml)
     workers = _resolve_workers(args.workers)
     base_config = BacktestConfig(starting_capital_krw=args.starting_capital)
     grid = default_grid()

--- a/tests/test_backtest_cli.py
+++ b/tests/test_backtest_cli.py
@@ -746,3 +746,81 @@ class TestMainExitCode:
             ]
         )
         assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. _resolve_symbols — universe_yaml 인자 (RED: --universe-yaml 미구현)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSymbolsUniverseYaml:
+    def test_명시적_path_전달_load_kospi200_universe_path_호출(self, monkeypatch):
+        """universe_yaml=Path('/custom/path.yaml') 전달 시
+        load_kospi200_universe(path) 가 정확히 그 경로로 호출된다."""
+        call_args: list = []
+        fake_universe = type("U", (), {"tickers": ("005930", "000660")})()
+
+        def spy(path):
+            call_args.append(path)
+            return fake_universe
+
+        monkeypatch.setattr(backtest_cli, "load_kospi200_universe", spy)
+        custom_path = Path("/custom/path.yaml")
+        result = _resolve_symbols("", universe_yaml=custom_path)
+        assert result == ("005930", "000660")
+        assert len(call_args) == 1
+        assert call_args[0] == custom_path
+
+    def test_path_전달_raw_우선_universe_미호출(self, monkeypatch):
+        """raw='005930,000660', universe_yaml=Path('/x.yaml') →
+        tuple('005930','000660') 반환, load_kospi200_universe 호출 0회."""
+        call_count: list = []
+
+        def spy(path=None):
+            call_count.append(True)
+            return type("U", (), {"tickers": ()})()
+
+        monkeypatch.setattr(backtest_cli, "load_kospi200_universe", spy)
+        result = _resolve_symbols("005930,000660", universe_yaml=Path("/x.yaml"))
+        assert result == ("005930", "000660")
+        assert len(call_count) == 0
+
+    def test_universe_yaml_None_인자_없이_호출(self, monkeypatch):
+        """universe_yaml=None 키워드 전달 시 load_kospi200_universe() 를
+        인자 없이(zero-arg) 호출하는 분기에 진입한다."""
+        call_log: list = []
+        fake_universe = type("U", (), {"tickers": ("035420",)})()
+
+        def spy_noarg():
+            call_log.append("noarg")
+            return fake_universe
+
+        monkeypatch.setattr(backtest_cli, "load_kospi200_universe", spy_noarg)
+        result = _resolve_symbols("", universe_yaml=None)
+        assert result == ("035420",)
+        assert call_log == ["noarg"]
+
+
+# ---------------------------------------------------------------------------
+# 10. _parse_args — --universe-yaml 옵션 (RED: 미구현)
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgsUniverseYaml:
+    _BASE = ["--csv-dir=/tmp/dummy", "--from=2023-01-01", "--to=2025-12-31"]
+
+    def test_기본값_config_universe_yaml(self):
+        """--universe-yaml 미지정 시 args.universe_yaml == Path('config/universe.yaml')."""
+        args = _parse_args(self._BASE)
+        assert args.universe_yaml == Path("config/universe.yaml")
+
+    def test_명시적_전달_상대경로(self):
+        """--universe-yaml=config/universe_top50.yaml →
+        args.universe_yaml == Path('config/universe_top50.yaml')."""
+        args = _parse_args(self._BASE + ["--universe-yaml=config/universe_top50.yaml"])
+        assert args.universe_yaml == Path("config/universe_top50.yaml")
+
+    def test_절대경로_isinstance_Path(self):
+        """--universe-yaml=/abs/path.yaml → isinstance(args.universe_yaml, Path) True."""
+        args = _parse_args(self._BASE + ["--universe-yaml=/abs/path.yaml"])
+        assert isinstance(args.universe_yaml, Path)

--- a/tests/test_build_liquidity_ranking.py
+++ b/tests/test_build_liquidity_ranking.py
@@ -1,0 +1,721 @@
+"""scripts/build_liquidity_ranking.py 공개 계약 단위 테스트 (RED 명세).
+
+build_ranking / main(exit code) 를 검증한다.
+pykrx, BusinessDayCalendar, load_kospi200_universe 는 전부 MagicMock 으로 교체.
+실 pykrx 네트워크·실 KIS 호출·실 wall-clock 없음. 파일 I/O 는 tmp_path 만.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# scripts/build_liquidity_ranking.py 로드
+# (scripts/ 에 __init__.py 없음 — spec_from_file_location, backfill_cli 와 동일 패턴)
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "build_liquidity_ranking.py"
+
+_src = str(_PROJECT_ROOT / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+_LOAD_ERROR: Exception | None = None
+liquidity_cli = None  # type: ignore[assignment]
+
+try:
+    _spec = importlib.util.spec_from_file_location("liquidity_cli", _SCRIPT_PATH)
+    if _spec is None or _spec.loader is None:
+        raise ImportError(f"spec_from_file_location 이 None 반환: {_SCRIPT_PATH}")
+    liquidity_cli = importlib.util.module_from_spec(_spec)
+    sys.modules["liquidity_cli"] = liquidity_cli
+    _spec.loader.exec_module(liquidity_cli)  # type: ignore[union-attr]
+except Exception as _e:
+    _LOAD_ERROR = _e
+
+
+def _require_module() -> None:
+    """각 테스트 시작 시 호출 — 모듈 로드 실패면 pytest.fail() 로 FAIL."""
+    if _LOAD_ERROR is not None:
+        pytest.fail(
+            f"scripts/build_liquidity_ranking.py 로드 실패 (RED 예상): {_LOAD_ERROR}",
+            pytrace=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 공개 심볼 참조 래퍼
+# ---------------------------------------------------------------------------
+
+
+def build_ranking(**kwargs):  # type: ignore[misc]
+    _require_module()
+    return liquidity_cli.build_ranking(**kwargs)  # type: ignore[union-attr]
+
+
+def main(argv=None):  # type: ignore[misc]
+    _require_module()
+    return liquidity_cli.main(argv)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# 외부 의존 심볼
+# ---------------------------------------------------------------------------
+
+from stock_agent.data import (  # noqa: E402
+    BusinessDayCalendar,
+    UniverseLoadError,
+)
+
+# ---------------------------------------------------------------------------
+# 상수 / 헬퍼
+# ---------------------------------------------------------------------------
+
+_SYM_A = "005930"  # 삼성전자
+_SYM_B = "000660"  # SK하이닉스
+
+
+def _make_mini_universe_yaml(tmp_path: Path, tickers: list[str]) -> Path:
+    """테스트용 최소 universe.yaml 을 tmp_path 에 작성하고 경로를 반환한다."""
+    yaml_path = tmp_path / "universe.yaml"
+    tickers_str = "\n".join(f'  - "{t}"' for t in tickers)
+    yaml_path.write_text(
+        f"as_of_date: 2026-01-01\nsource: test\ntickers:\n{tickers_str}\n",
+        encoding="utf-8",
+    )
+    return yaml_path
+
+
+def _make_calendar_stub(business_days: set[date]) -> MagicMock:
+    """지정된 날짜만 영업일로 반환하는 BusinessDayCalendar 더블."""
+    cal = MagicMock(spec=BusinessDayCalendar)
+    cal.is_business_day.side_effect = lambda d: d in business_days
+    return cal
+
+
+def _make_pykrx_factory(day_data: dict[date, dict[str, dict[str, int]]]):
+    """
+    day_data: {date: {symbol: {"종가": int, "거래대금": int}}}
+    pykrx.stock.get_market_ohlcv_by_ticker(yyyymmdd, market="KOSPI") → DataFrame 더블 반환.
+    DataFrame 더블은 iterrows() / __contains__ / __getitem__ 지원 MagicMock.
+    """
+    try:
+        import pandas as pd
+
+        def _factory():
+            pykrx_mock = MagicMock()
+
+            def _get_market_ohlcv_by_ticker(yyyymmdd: str, market: str = "KOSPI"):
+                d = date(int(yyyymmdd[:4]), int(yyyymmdd[4:6]), int(yyyymmdd[6:8]))
+                rows = day_data.get(d, {})
+                if not rows:
+                    return pd.DataFrame()
+                # 인덱스가 종목코드, 컬럼에 "종가"·"거래대금" 포함
+                records = {sym: vals for sym, vals in rows.items()}
+                df = pd.DataFrame.from_dict(records, orient="index")
+                return df
+
+            pykrx_mock.stock.get_market_ohlcv_by_ticker.side_effect = _get_market_ohlcv_by_ticker
+            return pykrx_mock
+
+        return _factory
+    except ImportError:
+        # pandas 없을 경우 fallback — 테스트는 ImportError 로 FAIL
+        return lambda: MagicMock()
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    """CSV 파일을 읽어 헤더 기반 dict list 반환."""
+    with open(path, encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def _make_3day_factory(
+    sym_a_closes: list[int],
+    sym_a_values: list[int],
+    sym_b_closes: list[int],
+    sym_b_values: list[int],
+    days: list[date],
+) -> object:
+    """3영업일 × 2종목 표준 팩토리 생성 헬퍼."""
+    assert len(days) == 3
+    day_data: dict[date, dict[str, dict[str, int]]] = {}
+    for i, d in enumerate(days):
+        day_data[d] = {
+            _SYM_A: {"종가": sym_a_closes[i], "거래대금": sym_a_values[i]},
+            _SYM_B: {"종가": sym_b_closes[i], "거래대금": sym_b_values[i]},
+        }
+    return _make_pykrx_factory(day_data)
+
+
+# ===========================================================================
+# A. build_ranking 정상 케이스
+# ===========================================================================
+
+
+class TestBuildRankingNormal:
+    """A-1 ~ A-4: 정상 경로 검증."""
+
+    # 3영업일
+    _DAYS = [date(2026, 1, 2), date(2026, 1, 5), date(2026, 1, 6)]
+
+    def test_A1_단순_2종목_3영업일_CSV_헤더_및_평균거래대금(self, tmp_path: Path):
+        """2종목 × 3영업일 — 헤더, 평균 거래대금(반올림 정수), sample_days=3 검증."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A, _SYM_B])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        # SYM_A: 거래대금 300, 200, 100 → 평균 200
+        # SYM_B: 거래대금 600, 600, 600 → 평균 600
+        factory = _make_3day_factory(
+            sym_a_closes=[10000, 10100, 10200],
+            sym_a_values=[300, 200, 100],
+            sym_b_closes=[50000, 51000, 52000],
+            sym_b_values=[600, 600, 600],
+            days=self._DAYS,
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        assert output_csv.exists(), "output_csv 가 생성되어야 한다"
+        rows = _read_csv_rows(output_csv)
+        # 헤더 컬럼 정확
+        assert set(rows[0].keys()) == {
+            "symbol",
+            "avg_value_krw",
+            "daily_return_std",
+            "sample_days",
+            "rank_value",
+        }
+        # sample_days = 3
+        for row in rows:
+            assert int(row["sample_days"]) == 3
+        # SYM_B 평균 거래대금 = 600, SYM_A = 200
+        by_sym = {r["symbol"]: r for r in rows}
+        assert int(by_sym[_SYM_A]["avg_value_krw"]) == 200
+        assert int(by_sym[_SYM_B]["avg_value_krw"]) == 600
+
+    def test_A1_rank_value_높은_평균이_1(self, tmp_path: Path):
+        """평균 거래대금이 높은 종목의 rank_value = 1."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A, _SYM_B])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        factory = _make_3day_factory(
+            sym_a_closes=[10000, 10100, 10200],
+            sym_a_values=[100, 100, 100],  # SYM_A 낮음
+            sym_b_closes=[50000, 51000, 52000],
+            sym_b_values=[900, 900, 900],  # SYM_B 높음
+            days=self._DAYS,
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        rows = _read_csv_rows(output_csv)
+        by_sym = {r["symbol"]: r for r in rows}
+        assert int(by_sym[_SYM_B]["rank_value"]) == 1
+        assert int(by_sym[_SYM_A]["rank_value"]) == 2
+
+    def test_A1_daily_return_std_ddof1(self, tmp_path: Path):
+        """daily_return std(ddof=1) 정확도 검증.
+
+        SYM_A 종가: [10000, 10100, 10200]
+        returns: [(10100/10000)-1, (10200/10100)-1] = [0.01, ~0.009901]
+        std(ddof=1) ≈ 0.000070...
+        """
+        _require_module()
+        import math
+
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        factory = _make_pykrx_factory(
+            {
+                self._DAYS[0]: {_SYM_A: {"종가": 10000, "거래대금": 100}},
+                self._DAYS[1]: {_SYM_A: {"종가": 10100, "거래대금": 100}},
+                self._DAYS[2]: {_SYM_A: {"종가": 10200, "거래대금": 100}},
+            }
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        rows = _read_csv_rows(output_csv)
+        assert len(rows) == 1
+        std_val = float(rows[0]["daily_return_std"])
+
+        # 수동 계산: returns = [0.01, 10200/10100 - 1]
+        r1 = 10100 / 10000 - 1
+        r2 = 10200 / 10100 - 1
+        mean_r = (r1 + r2) / 2
+        expected_std = math.sqrt(((r1 - mean_r) ** 2 + (r2 - mean_r) ** 2) / 1)
+        assert abs(std_val - expected_std) < 1e-9, f"std={std_val!r} expected≈{expected_std!r}"
+
+    def test_A2_sample_days_종목별_차이(self, tmp_path: Path):
+        """한 종목이 1일 누락되면 sample_days=2 로 기록된다."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A, _SYM_B])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        # SYM_B 는 day1 에 데이터 없음 → sample_days=2
+        factory = _make_pykrx_factory(
+            {
+                self._DAYS[0]: {
+                    _SYM_A: {"종가": 10000, "거래대금": 100},
+                    # _SYM_B 없음
+                },
+                self._DAYS[1]: {
+                    _SYM_A: {"종가": 10100, "거래대금": 100},
+                    _SYM_B: {"종가": 50000, "거래대금": 500},
+                },
+                self._DAYS[2]: {
+                    _SYM_A: {"종가": 10200, "거래대금": 100},
+                    _SYM_B: {"종가": 51000, "거래대금": 500},
+                },
+            }
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        rows = _read_csv_rows(output_csv)
+        by_sym = {r["symbol"]: r for r in rows}
+        assert int(by_sym[_SYM_A]["sample_days"]) == 3
+        assert int(by_sym[_SYM_B]["sample_days"]) == 2
+
+    def test_A3_rank_value_tiebreak_symbol_오름차순(self, tmp_path: Path):
+        """평균 거래대금 동일 시 symbol 오름차순이 rank_value 낮음."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A, _SYM_B])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        # 동일 거래대금
+        factory = _make_3day_factory(
+            sym_a_closes=[10000, 10100, 10200],
+            sym_a_values=[500, 500, 500],
+            sym_b_closes=[50000, 51000, 52000],
+            sym_b_values=[500, 500, 500],
+            days=self._DAYS,
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        rows = _read_csv_rows(output_csv)
+        by_sym = {r["symbol"]: r for r in rows}
+        # SYM_A("005930") < SYM_B("000660") 는 거짓 → "000660" < "005930"
+        # 따라서 000660 이 rank_value=1
+        assert int(by_sym[_SYM_B]["rank_value"]) == 1  # "000660" < "005930"
+        assert int(by_sym[_SYM_A]["rank_value"]) == 2
+
+    def test_A4_output_directory_자동_생성(self, tmp_path: Path):
+        """output_csv.parent 가 존재하지 않아도 자동으로 mkdir 된다."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        deep_dir = tmp_path / "deep" / "nested"
+        output_csv = deep_dir / "ranking.csv"
+        assert not deep_dir.exists()
+
+        cal = _make_calendar_stub({self._DAYS[0]})
+        factory = _make_pykrx_factory({self._DAYS[0]: {_SYM_A: {"종가": 10000, "거래대금": 100}}})
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[0],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        assert output_csv.exists()
+
+
+# ===========================================================================
+# B. 누락 종목 / 영업일 필터
+# ===========================================================================
+
+
+class TestBuildRankingFilters:
+    """B-5 ~ B-7: 누락 종목 처리·영업일 필터 검증."""
+
+    _DAYS = [date(2026, 1, 2), date(2026, 1, 5), date(2026, 1, 6)]
+
+    def test_B5_유니버스에_있으나_pykrx에_없는_종목_경고_후_제외(self, tmp_path: Path, caplog):
+        """유니버스에 있지만 모든 영업일 pykrx DataFrame에 없는 종목은 결과 CSV 에서 제외된다."""
+        _require_module()
+
+        # SYM_A 만 universe 에 있고, pykrx 에도 있음
+        # SYM_B 는 universe 에 있지만 pykrx 에 없음
+        _SYM_MISSING = "999999"
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A, _SYM_MISSING])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(self._DAYS))
+
+        factory = _make_pykrx_factory(
+            {
+                d: {_SYM_A: {"종가": 10000 + i * 100, "거래대금": 100}}
+                for i, d in enumerate(self._DAYS)
+            }
+        )
+
+        build_ranking(
+            start=self._DAYS[0],
+            end=self._DAYS[-1],
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=factory,
+            calendar=cal,
+        )
+
+        rows = _read_csv_rows(output_csv)
+        symbols_in_csv = {r["symbol"] for r in rows}
+        # 누락 종목은 결과에서 제외
+        assert _SYM_MISSING not in symbols_in_csv
+        assert _SYM_A in symbols_in_csv
+
+    def test_B6_주말_skip_pykrx_호출_없음(self, tmp_path: Path):
+        """start=금, end=월 — 토·일은 pykrx 호출이 발생하지 않는다."""
+        _require_module()
+        # 2026-01-02(금), 2026-01-03(토), 2026-01-04(일), 2026-01-05(월) — 토·일은
+        # 캘린더가 비영업일로 가짜 표시. 호출 로그로 skip 검증.
+        fri = date(2026, 1, 2)
+        mon = date(2026, 1, 5)
+
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        # 캘린더: 금·월만 영업일
+        cal = _make_calendar_stub({fri, mon})
+
+        call_log: list[str] = []
+
+        import pandas as pd
+
+        def _factory():
+            pykrx_mock = MagicMock()
+
+            def _get(yyyymmdd: str, market: str = "KOSPI"):
+                call_log.append(yyyymmdd)
+                d = date(int(yyyymmdd[:4]), int(yyyymmdd[4:6]), int(yyyymmdd[6:8]))
+                if d in (fri, mon):
+                    return pd.DataFrame.from_dict(
+                        {_SYM_A: {"종가": 10000, "거래대금": 100}}, orient="index"
+                    )
+                return pd.DataFrame()
+
+            pykrx_mock.stock.get_market_ohlcv_by_ticker.side_effect = _get
+            return pykrx_mock
+
+        build_ranking(
+            start=fri,
+            end=mon,
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=_factory,
+            calendar=cal,
+        )
+
+        # 토·일에 대응하는 yyyymmdd 호출이 없어야 한다
+        assert "20260103" not in call_log, "토요일 pykrx 호출 발생"
+        assert "20260104" not in call_log, "일요일 pykrx 호출 발생"
+        assert "20260102" in call_log, "금요일 pykrx 호출 누락"
+        assert "20260105" in call_log, "월요일 pykrx 호출 누락"
+
+    def test_B7_공휴일_skip_calendar_false_날짜_호출_없음(self, tmp_path: Path):
+        """calendar.is_business_day=False 인 평일은 pykrx 호출이 발생하지 않는다."""
+        _require_module()
+        # 2026-01-02(금), 2026-01-05(월 — 공휴일로 처리)
+        fri = date(2026, 1, 2)
+        mon_holiday = date(2026, 1, 5)
+
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        # 금만 영업일, 월은 공휴일
+        cal = _make_calendar_stub({fri})
+
+        call_log: list[str] = []
+
+        import pandas as pd
+
+        def _factory():
+            pykrx_mock = MagicMock()
+
+            def _get(yyyymmdd: str, market: str = "KOSPI"):
+                call_log.append(yyyymmdd)
+                return pd.DataFrame.from_dict(
+                    {_SYM_A: {"종가": 10000, "거래대금": 100}}, orient="index"
+                )
+
+            pykrx_mock.stock.get_market_ohlcv_by_ticker.side_effect = _get
+            return pykrx_mock
+
+        build_ranking(
+            start=fri,
+            end=mon_holiday,
+            universe_yaml=universe_yaml,
+            output_csv=output_csv,
+            pykrx_factory=_factory,
+            calendar=cal,
+        )
+
+        assert "20260105" not in call_log, "공휴일(월) pykrx 호출 발생"
+        assert "20260102" in call_log, "영업일(금) pykrx 호출 누락"
+
+
+# ===========================================================================
+# C. fail-fast / 입력 가드
+# ===========================================================================
+
+
+class TestBuildRankingGuards:
+    """C-8 ~ C-11: 입력 검증·fail-fast."""
+
+    _BD = date(2026, 1, 2)
+
+    def _single_day_factory(self):
+        import pandas as pd
+
+        def _factory():
+            m = MagicMock()
+            m.stock.get_market_ohlcv_by_ticker.return_value = pd.DataFrame.from_dict(
+                {_SYM_A: {"종가": 10000, "거래대금": 100}}, orient="index"
+            )
+            return m
+
+        return _factory
+
+    def test_C8_start_after_end_RuntimeError(self, tmp_path: Path):
+        """start > end 이면 RuntimeError 가 발생한다."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub({self._BD})
+
+        with pytest.raises(RuntimeError):
+            build_ranking(
+                start=date(2026, 1, 10),
+                end=date(2026, 1, 5),
+                universe_yaml=universe_yaml,
+                output_csv=output_csv,
+                pykrx_factory=self._single_day_factory(),
+                calendar=cal,
+            )
+
+    def test_C9_영업일_0개_RuntimeError(self, tmp_path: Path):
+        """start..end 범위에 영업일이 0개면 RuntimeError 가 발생한다."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        # 모든 날짜가 비영업일
+        cal = _make_calendar_stub(set())  # 영업일 없음
+
+        with pytest.raises(RuntimeError):
+            build_ranking(
+                start=date(2026, 1, 3),  # 토
+                end=date(2026, 1, 4),  # 일
+                universe_yaml=universe_yaml,
+                output_csv=output_csv,
+                pykrx_factory=self._single_day_factory(),
+                calendar=cal,
+            )
+
+    def test_C10_50퍼센트_이상_영업일_pykrx_실패_RuntimeError(self, tmp_path: Path):
+        """영업일 10일 중 6일 빈 DataFrame → RuntimeError('excessive_failures: ...')."""
+        _require_module()
+        import pandas as pd
+
+        # 10영업일 생성 (2026-01-05 ~ 2026-01-16, 주말 제외 10일)
+        ten_days = [
+            date(2026, 1, 5),
+            date(2026, 1, 6),
+            date(2026, 1, 7),
+            date(2026, 1, 8),
+            date(2026, 1, 9),
+            date(2026, 1, 12),
+            date(2026, 1, 13),
+            date(2026, 1, 14),
+            date(2026, 1, 15),
+            date(2026, 1, 16),
+        ]
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub(set(ten_days))
+
+        # 처음 4일만 데이터, 나머지 6일 빈 DataFrame
+        good_days = set(ten_days[:4])
+
+        def _factory():
+            m = MagicMock()
+
+            def _get(yyyymmdd: str, market: str = "KOSPI"):
+                d = date(int(yyyymmdd[:4]), int(yyyymmdd[4:6]), int(yyyymmdd[6:8]))
+                if d in good_days:
+                    return pd.DataFrame.from_dict(
+                        {_SYM_A: {"종가": 10000, "거래대금": 100}}, orient="index"
+                    )
+                return pd.DataFrame()  # 빈 DataFrame
+
+            m.stock.get_market_ohlcv_by_ticker.side_effect = _get
+            return m
+
+        with pytest.raises(RuntimeError, match="excessive_failures"):
+            build_ranking(
+                start=ten_days[0],
+                end=ten_days[-1],
+                universe_yaml=universe_yaml,
+                output_csv=output_csv,
+                pykrx_factory=_factory,
+                calendar=cal,
+            )
+
+    def test_C11_universe_yaml_누락_UniverseLoadError_전파(self, tmp_path: Path):
+        """universe_yaml 이 존재하지 않으면 UniverseLoadError 가 그대로 전파된다."""
+        _require_module()
+        missing_yaml = tmp_path / "nonexistent_universe.yaml"
+        output_csv = tmp_path / "ranking.csv"
+        cal = _make_calendar_stub({date(2026, 1, 2)})
+
+        import pandas as pd
+
+        def _factory():
+            m = MagicMock()
+            m.stock.get_market_ohlcv_by_ticker.return_value = pd.DataFrame()
+            return m
+
+        with pytest.raises(UniverseLoadError):
+            build_ranking(
+                start=date(2026, 1, 2),
+                end=date(2026, 1, 2),
+                universe_yaml=missing_yaml,
+                output_csv=output_csv,
+                pykrx_factory=_factory,
+                calendar=cal,
+            )
+
+
+# ===========================================================================
+# D. CLI main()
+# ===========================================================================
+
+
+class TestMainCli:
+    """D-12 ~ D-14: CLI main() exit code 검증."""
+
+    def _patch_build_ranking(self, monkeypatch, *, side_effect=None, return_value=None):
+        """build_ranking 을 monkeypatch 로 대체."""
+        _require_module()
+        if side_effect is not None:
+            mock = MagicMock(side_effect=side_effect)
+        else:
+            mock = MagicMock(return_value=return_value)
+        monkeypatch.setattr(liquidity_cli, "build_ranking", mock)
+        return mock
+
+    def test_D12_정상_1영업일_CSV_생성_return_0(self, tmp_path: Path, monkeypatch):
+        """정상 경로 — 1영업일 mock pykrx → CSV 생성 + return 0."""
+        _require_module()
+
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+
+        # build_ranking 을 실제 호출이 아닌 mock 으로 교체
+        # (main 이 build_ranking 을 올바르게 호출하는지만 검증)
+        mock_br = self._patch_build_ranking(monkeypatch)
+
+        result = main(
+            [
+                "--start=2026-01-02",
+                "--end=2026-01-02",
+                f"--universe-yaml={universe_yaml}",
+                f"--output-csv={output_csv}",
+            ]
+        )
+
+        assert result == 0
+        mock_br.assert_called_once()
+
+    def test_D13_입력_오류_start_after_end_return_2(self, tmp_path: Path, monkeypatch):
+        """start > end → return 2."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+
+        # build_ranking 이 RuntimeError 를 raise 하도록
+        self._patch_build_ranking(monkeypatch, side_effect=RuntimeError("start > end"))
+
+        result = main(
+            [
+                "--start=2026-01-10",
+                "--end=2026-01-05",
+                f"--universe-yaml={universe_yaml}",
+                f"--output-csv={output_csv}",
+            ]
+        )
+
+        assert result == 2
+
+    def test_D14_IO_오류_readonly_디렉터리_return_3(self, tmp_path: Path, monkeypatch):
+        """output_csv 부모 디렉터리가 쓰기 불가 → return 3."""
+        _require_module()
+        universe_yaml = _make_mini_universe_yaml(tmp_path, [_SYM_A])
+        output_csv = tmp_path / "ranking.csv"
+
+        # build_ranking 이 OSError/PermissionError 를 raise 하도록
+        self._patch_build_ranking(monkeypatch, side_effect=OSError("Permission denied"))
+
+        result = main(
+            [
+                "--start=2026-01-02",
+                "--end=2026-01-02",
+                f"--universe-yaml={universe_yaml}",
+                f"--output-csv={output_csv}",
+            ]
+        )
+
+        assert result == 3

--- a/tests/test_build_universe_subset.py
+++ b/tests/test_build_universe_subset.py
@@ -1,0 +1,522 @@
+"""scripts/build_universe_subset.py 공개 계약 단위 테스트 (RED 명세).
+
+build_subset / main(exit code) 를 검증한다.
+실 KIS·pykrx·네트워크 호출 0. 파일 I/O 는 tmp_path 만.
+load_kospi200_universe 는 실제 구현을 사용하되 tmp_path yaml 에만 접근한다.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# scripts/build_universe_subset.py 동적 로드
+# (scripts/ 에 __init__.py 없음 — spec_from_file_location, build_liquidity_ranking 과 동일 패턴)
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "build_universe_subset.py"
+
+_src = str(_PROJECT_ROOT / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+_LOAD_ERROR: Exception | None = None
+subset_cli = None  # type: ignore[assignment]
+
+try:
+    _spec = importlib.util.spec_from_file_location("subset_cli", _SCRIPT_PATH)
+    if _spec is None or _spec.loader is None:
+        raise ImportError(f"spec_from_file_location 이 None 반환: {_SCRIPT_PATH}")
+    subset_cli = importlib.util.module_from_spec(_spec)
+    sys.modules["subset_cli"] = subset_cli
+    _spec.loader.exec_module(subset_cli)  # type: ignore[union-attr]
+except Exception as _e:
+    _LOAD_ERROR = _e
+
+
+def _require_module() -> None:
+    """각 테스트 시작 시 호출 — 모듈 로드 실패면 pytest.fail() 로 FAIL."""
+    if _LOAD_ERROR is not None:
+        pytest.fail(
+            f"scripts/build_universe_subset.py 로드 실패 (RED 예상): {_LOAD_ERROR}",
+            pytrace=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 공개 심볼 참조 래퍼
+# ---------------------------------------------------------------------------
+
+
+def build_subset(**kwargs):  # type: ignore[misc]
+    _require_module()
+    return subset_cli.build_subset(**kwargs)  # type: ignore[union-attr]
+
+
+def main(argv=None):  # type: ignore[misc]
+    _require_module()
+    return subset_cli.main(argv)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# 외부 의존 심볼
+# ---------------------------------------------------------------------------
+
+from stock_agent.data import (  # noqa: E402
+    KospiUniverse,
+    load_kospi200_universe,
+)
+
+# ---------------------------------------------------------------------------
+# 상수 / 헬퍼
+# ---------------------------------------------------------------------------
+
+# 테스트용 6자리 티커 5종 (알파벳 정렬 순서 고정)
+_SYM_1 = "000660"  # rank_value=1 (가장 앞 alphabetically, 첫 번째로 테스트)
+_SYM_2 = "005930"
+_SYM_3 = "035420"
+_SYM_4 = "051910"
+_SYM_5 = "066570"
+
+_ALL_SYMS = [_SYM_1, _SYM_2, _SYM_3, _SYM_4, _SYM_5]
+
+
+def _write_ranking_csv(
+    path: Path,
+    rows: list[dict[str, str]],
+) -> None:
+    """ranking CSV 를 tmp_path 에 작성한다. rows 는 헤더 순서대로 dict."""
+    fieldnames = ["symbol", "avg_value_krw", "daily_return_std", "sample_days", "rank_value"]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _make_standard_ranking_csv(tmp_path: Path, symbols: list[str] | None = None) -> Path:
+    """5종목 표준 ranking CSV 를 tmp_path/ranking.csv 에 작성한다.
+    rank_value 는 1~5, avg_value_krw 내림차순 (rank 1 이 최대)."""
+    syms = symbols if symbols is not None else _ALL_SYMS
+    csv_path = tmp_path / "ranking.csv"
+    rows = []
+    for i, sym in enumerate(syms):
+        rank = i + 1
+        rows.append(
+            {
+                "symbol": sym,
+                "avg_value_krw": str(1_000_000 - i * 100_000),
+                "daily_return_std": "0.010000",
+                "sample_days": "20",
+                "rank_value": str(rank),
+            }
+        )
+    _write_ranking_csv(csv_path, rows)
+    return csv_path
+
+
+def _read_output_yaml(path: Path) -> dict:
+    """작성된 output yaml 을 dict 로 읽는다."""
+    import yaml
+
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ===========================================================================
+# A. build_subset 정상 케이스
+# ===========================================================================
+
+
+class TestBuildSubsetNormal:
+    """A-1 ~ A-4: 정상 경로 검증."""
+
+    _AS_OF = date(2025, 4, 21)
+    _SOURCE = "liquidity_ranking_top3"
+
+    def test_A1_top3_추출_tickers_길이_및_포함(self, tmp_path: Path):
+        """5종목 ranking CSV + top_n=3 → yaml tickers 길이 3, rank 1·2·3 종목 포함."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        build_subset(
+            ranking_csv=csv_path,
+            top_n=3,
+            output_yaml=output_yaml,
+            source=self._SOURCE,
+            as_of=self._AS_OF,
+        )
+
+        assert output_yaml.exists(), "output_yaml 이 생성되어야 한다"
+        data = _read_output_yaml(output_yaml)
+        tickers = data["tickers"]
+        assert len(tickers) == 3, f"tickers 길이 3 기대, got {len(tickers)}"
+        # rank 1·2·3 종목이 포함되어야 한다
+        for sym in _ALL_SYMS[:3]:
+            assert sym in tickers, f"{sym} 이 tickers 에 없다"
+        # rank 4·5 는 제외
+        for sym in _ALL_SYMS[3:]:
+            assert sym not in tickers, f"{sym} 이 tickers 에 포함되면 안 된다"
+
+    def test_A2_yaml_schema_정확(self, tmp_path: Path):
+        """as_of_date 가 ISO 문자열, source 가 인자 그대로, tickers 가 6자리 + 정렬."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+        source_str = "test-source-2026"
+
+        build_subset(
+            ranking_csv=csv_path,
+            top_n=3,
+            output_yaml=output_yaml,
+            source=source_str,
+            as_of=self._AS_OF,
+        )
+
+        data = _read_output_yaml(output_yaml)
+
+        # as_of_date 는 YYYY-MM-DD ISO 문자열
+        assert "as_of_date" in data, "as_of_date 키 없음"
+        as_of_val = data["as_of_date"]
+        # yaml 로더가 date 객체로 파싱할 수 있으므로 str 또는 date 모두 허용
+        as_of_str = as_of_val.isoformat() if isinstance(as_of_val, date) else str(as_of_val)
+        assert as_of_str == self._AS_OF.isoformat(), f"as_of_date 불일치: {as_of_str!r}"
+
+        # source 가 인자 그대로
+        assert data.get("source") == source_str, f"source 불일치: {data.get('source')!r}"
+
+        # tickers 는 리스트, 6자리 숫자 문자열, 정렬
+        tickers = data["tickers"]
+        assert isinstance(tickers, list), "tickers 가 list 가 아님"
+        for t in tickers:
+            ticker_msg = f"ticker {t!r} 가 6자리 숫자 문자열이 아님"
+            assert isinstance(t, str) and len(t) == 6 and t.isdigit(), ticker_msg
+        assert tickers == sorted(tickers), f"tickers 가 정렬되지 않음: {tickers}"
+
+    def test_A3_load_kospi200_universe_자체검증_통과(self, tmp_path: Path):
+        """작성된 yaml 을 load_kospi200_universe 로 다시 읽어 KospiUniverse 복원."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+        source_str = "step-c-test"
+
+        build_subset(
+            ranking_csv=csv_path,
+            top_n=3,
+            output_yaml=output_yaml,
+            source=source_str,
+            as_of=self._AS_OF,
+        )
+
+        # 로더로 재검증
+        universe = load_kospi200_universe(output_yaml)
+        assert isinstance(universe, KospiUniverse)
+        assert universe.as_of_date == self._AS_OF
+        assert universe.source == source_str
+        assert len(universe.tickers) == 3
+        # rank 1~3 종목이 tuple 에 포함
+        for sym in _ALL_SYMS[:3]:
+            assert sym in universe.tickers, f"{sym} 이 universe.tickers 에 없다"
+
+    def test_A4_출력_디렉터리_자동_생성(self, tmp_path: Path):
+        """output_yaml.parent 미존재 → mkdir 후 파일 작성."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        deep_dir = tmp_path / "nested" / "deep" / "dir"
+        output_yaml = deep_dir / "subset.yaml"
+        assert not deep_dir.exists(), "사전 조건: 디렉터리가 없어야 한다"
+
+        build_subset(
+            ranking_csv=csv_path,
+            top_n=2,
+            output_yaml=output_yaml,
+            source="auto-mkdir-test",
+            as_of=self._AS_OF,
+        )
+
+        assert output_yaml.exists(), "출력 파일이 생성되어야 한다"
+
+
+# ===========================================================================
+# B. fail-fast / 입력 가드
+# ===========================================================================
+
+
+class TestBuildSubsetGuards:
+    """B-5 ~ B-9: 입력 검증·fail-fast."""
+
+    _AS_OF = date(2025, 4, 21)
+
+    def test_B5_top_n_zero_RuntimeError(self, tmp_path: Path):
+        """top_n=0 → RuntimeError."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=0,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    def test_B5_top_n_negative_RuntimeError(self, tmp_path: Path):
+        """top_n=-1 → RuntimeError."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=-1,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    def test_B6_top_n_초과_RuntimeError(self, tmp_path: Path):
+        """top_n=10 인데 CSV 에 종목이 5개뿐 → RuntimeError."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)  # 5종목
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=10,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    def test_B7_ranking_csv_누락_FileNotFoundError_또는_OSError(self, tmp_path: Path):
+        """ranking_csv 가 존재하지 않으면 FileNotFoundError 또는 OSError."""
+        _require_module()
+        missing_csv = tmp_path / "nonexistent_ranking.csv"
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises((FileNotFoundError, OSError)):
+            build_subset(
+                ranking_csv=missing_csv,
+                top_n=3,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    def test_B8_csv_헤더_rank_value_컬럼_부재_RuntimeError(self, tmp_path: Path):
+        """rank_value 컬럼이 없는 CSV → RuntimeError."""
+        _require_module()
+        csv_path = tmp_path / "bad_ranking.csv"
+        # rank_value 없는 헤더
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["symbol", "avg_value_krw", "daily_return_std", "sample_days"]
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "symbol": "005930",
+                    "avg_value_krw": "1000000",
+                    "daily_return_std": "0.01",
+                    "sample_days": "20",
+                }
+            )
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=1,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    def test_B8_csv_헤더_완전_누락_RuntimeError(self, tmp_path: Path):
+        """헤더가 전혀 없는 빈 CSV (0바이트) → RuntimeError."""
+        _require_module()
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("", encoding="utf-8")
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=1,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+    @pytest.mark.parametrize(
+        "bad_rows",
+        [
+            pytest.param(
+                [
+                    {
+                        "symbol": "000660",
+                        "avg_value_krw": "900000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "-1",
+                    },
+                    {
+                        "symbol": "005930",
+                        "avg_value_krw": "800000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "2",
+                    },
+                ],
+                id="음수_rank_value",
+            ),
+            pytest.param(
+                [
+                    {
+                        "symbol": "000660",
+                        "avg_value_krw": "900000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "1",
+                    },
+                    {
+                        "symbol": "005930",
+                        "avg_value_krw": "800000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "1",
+                    },
+                ],
+                id="중복_rank_value",
+            ),
+            pytest.param(
+                [
+                    {
+                        "symbol": "000660",
+                        "avg_value_krw": "900000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "2",
+                    },
+                    {
+                        "symbol": "005930",
+                        "avg_value_krw": "800000",
+                        "daily_return_std": "0.01",
+                        "sample_days": "20",
+                        "rank_value": "3",
+                    },
+                ],
+                id="rank_value_1_누락",
+            ),
+        ],
+    )
+    def test_B9_잘못된_rank_value_RuntimeError(self, tmp_path: Path, bad_rows: list[dict]):
+        """음수·중복·1..top_n 빠진 rank_value → RuntimeError."""
+        _require_module()
+        csv_path = tmp_path / "bad_rank.csv"
+        _write_ranking_csv(csv_path, bad_rows)
+        output_yaml = tmp_path / "subset.yaml"
+
+        with pytest.raises(RuntimeError):
+            build_subset(
+                ranking_csv=csv_path,
+                top_n=1,
+                output_yaml=output_yaml,
+                source="test",
+                as_of=self._AS_OF,
+            )
+
+
+# ===========================================================================
+# C. CLI main()
+# ===========================================================================
+
+
+class TestMainCli:
+    """C-10 ~ C-12: CLI main() exit code 검증."""
+
+    _AS_OF_STR = "2025-04-21"
+
+    def _patch_build_subset(self, monkeypatch, *, side_effect=None, return_value=None):
+        """build_subset 을 monkeypatch 로 대체."""
+        _require_module()
+        if side_effect is not None:
+            mock = MagicMock(side_effect=side_effect)
+        else:
+            mock = MagicMock(return_value=return_value)
+        monkeypatch.setattr(subset_cli, "build_subset", mock)
+        return mock
+
+    def test_C10_정상_return_0_yaml_생성(self, tmp_path: Path, monkeypatch):
+        """정상 경로 — build_subset mock 정상 반환 → return 0."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        mock_bs = self._patch_build_subset(monkeypatch)
+
+        result = main(
+            [
+                f"--ranking-csv={csv_path}",
+                "--top-n=3",
+                f"--output-yaml={output_yaml}",
+                "--source=test-source",
+                f"--as-of={self._AS_OF_STR}",
+            ]
+        )
+
+        assert result == 0
+        mock_bs.assert_called_once()
+
+    def test_C11_입력_오류_RuntimeError_return_2(self, tmp_path: Path, monkeypatch):
+        """build_subset 이 RuntimeError → return 2."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        self._patch_build_subset(monkeypatch, side_effect=RuntimeError("top_n <= 0"))
+
+        result = main(
+            [
+                f"--ranking-csv={csv_path}",
+                "--top-n=0",
+                f"--output-yaml={output_yaml}",
+                "--source=test-source",
+                f"--as-of={self._AS_OF_STR}",
+            ]
+        )
+
+        assert result == 2
+
+    def test_C12_IO_오류_OSError_return_3(self, tmp_path: Path, monkeypatch):
+        """build_subset 이 OSError → return 3."""
+        _require_module()
+        csv_path = _make_standard_ranking_csv(tmp_path)
+        output_yaml = tmp_path / "subset.yaml"
+
+        self._patch_build_subset(monkeypatch, side_effect=OSError("Permission denied"))
+
+        result = main(
+            [
+                f"--ranking-csv={csv_path}",
+                "--top-n=3",
+                f"--output-yaml={output_yaml}",
+                "--source=test-source",
+                f"--as-of={self._AS_OF_STR}",
+            ]
+        )
+
+        assert result == 3

--- a/tests/test_sensitivity_cli.py
+++ b/tests/test_sensitivity_cli.py
@@ -408,3 +408,84 @@ class TestResumeFlushCallback:
             f"on_row 가 callable 이 아님: {type(on_row_value)!r} = {on_row_value!r}\n"
             "--resume + --workers>=2 분기에서 on_row=_flush 를 주입해야 한다 (RED: 미구현)"
         )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_symbols — universe_yaml 인자 (RED: --universe-yaml 미구현)
+# ---------------------------------------------------------------------------
+
+_resolve_symbols = sensitivity_cli._resolve_symbols
+_parse_args = sensitivity_cli._parse_args
+
+
+class TestResolveSymbolsUniverseYaml:
+    def test_명시적_path_전달_load_kospi200_universe_path_호출(self, monkeypatch):
+        """universe_yaml=Path('/custom/path.yaml') 전달 시
+        load_kospi200_universe(path) 가 정확히 그 경로로 호출된다."""
+        call_args: list = []
+        fake_universe = type("U", (), {"tickers": ("005930", "000660")})()
+
+        def spy(path):
+            call_args.append(path)
+            return fake_universe
+
+        monkeypatch.setattr(sensitivity_cli, "load_kospi200_universe", spy)
+        custom_path = Path("/custom/path.yaml")
+        result = _resolve_symbols("", universe_yaml=custom_path)
+        assert result == ("005930", "000660")
+        assert len(call_args) == 1
+        assert call_args[0] == custom_path
+
+    def test_path_전달_raw_우선_universe_미호출(self, monkeypatch):
+        """raw='005930,000660', universe_yaml=Path('/x.yaml') →
+        tuple('005930','000660') 반환, load_kospi200_universe 호출 0회."""
+        call_count: list = []
+
+        def spy(path=None):
+            call_count.append(True)
+            return type("U", (), {"tickers": ()})()
+
+        monkeypatch.setattr(sensitivity_cli, "load_kospi200_universe", spy)
+        result = _resolve_symbols("005930,000660", universe_yaml=Path("/x.yaml"))
+        assert result == ("005930", "000660")
+        assert len(call_count) == 0
+
+    def test_universe_yaml_None_인자_없이_호출(self, monkeypatch):
+        """universe_yaml=None 키워드 전달 시 load_kospi200_universe() 를
+        인자 없이(zero-arg) 호출하는 분기에 진입한다."""
+        call_log: list = []
+        fake_universe = type("U", (), {"tickers": ("035420",)})()
+
+        def spy_noarg():
+            call_log.append("noarg")
+            return fake_universe
+
+        monkeypatch.setattr(sensitivity_cli, "load_kospi200_universe", spy_noarg)
+        result = _resolve_symbols("", universe_yaml=None)
+        assert result == ("035420",)
+        assert call_log == ["noarg"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_args — --universe-yaml 옵션 (RED: 미구현)
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgsUniverseYaml:
+    _BASE = ["--csv-dir=/tmp/dummy", "--from=2023-01-01", "--to=2025-12-31"]
+
+    def test_기본값_config_universe_yaml(self):
+        """--universe-yaml 미지정 시 args.universe_yaml == Path('config/universe.yaml')."""
+        args = _parse_args(self._BASE)
+        assert args.universe_yaml == Path("config/universe.yaml")
+
+    def test_명시적_전달_상대경로(self):
+        """--universe-yaml=config/universe_top50.yaml →
+        args.universe_yaml == Path('config/universe_top50.yaml')."""
+        args = _parse_args(self._BASE + ["--universe-yaml=config/universe_top50.yaml"])
+        assert args.universe_yaml == Path("config/universe_top50.yaml")
+
+    def test_절대경로_isinstance_Path(self):
+        """--universe-yaml=/abs/path.yaml → isinstance(args.universe_yaml, Path) True."""
+        args = _parse_args(self._BASE + ["--universe-yaml=/abs/path.yaml"])
+        assert isinstance(args.universe_yaml, Path)


### PR DESCRIPTION
## Summary
- ADR-0019 Phase 2 복구 로드맵 **Step C 인프라** 완료 (Issue #76).
- 신규 스크립트 2종: `build_liquidity_ranking.py` (pykrx bulk 거래대금/변동성 랭킹) + `build_universe_subset.py` (Top N 서브셋 yaml 빌더).
- 기존 CLI 2종 확장: `backtest.py` + `sensitivity.py` 에 `--universe-yaml PATH` 플래그 추가 (backward-compat, default `config/universe.yaml`).
- 운영자 실 데이터 실행 + 게이트 판정 + ADR 채택은 본 PR 범위 밖 — **후속 Issue #90** 트래킹.

## Test plan
- [x] pytest 1471 passed
- [x] ruff check + ruff format + black + pyright (src scripts tests) GREEN
- [ ] (Issue #90) 운영자 실 KIS 캐시로 Top 50/100 백테스트 실행 + 세 게이트 판정

## 관련
- Issue #76 (Step C 인프라 — 본 PR)
- Issue #90 (Step C 운영자 실행 + 세 게이트 판정 — 후속)
- ADR-0019 (Phase 2 복구 로드맵)
- ADR-0004 (KOSPI 200 YAML 수동 관리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)