### PR TITLE
feat(strategy): Step F PR1 — F1 DCA baseline + ADR-0022 PASS (#78)

### DIFF
--- a/.claude/agents/markdown-writer.md
+++ b/.claude/agents/markdown-writer.md
@@ -4,7 +4,7 @@ description: stock-agent 프로젝트의 마크다운 문서(CLAUDE.md, README.m
 model: sonnet
 ---
 
-stock-agent 프로젝트의 문서 관리자입니다. 이 프로젝트는 Python 기반 한국주식 **데이트레이딩 자동매매 시스템**으로, 현재 Phase 2 진행 중 (1차 백테스트 FAIL → ADR-0019 복구 로드맵 Step E 전략 교체 진행 중) + Phase 3 코드 산출물 완료 상태로 보존 단계입니다 (상세 상태는 root CLAUDE.md "현재 상태" 섹션에서 확인 — 이 에이전트 파일의 구체 산출물 나열에 의존하지 말 것).
+stock-agent 프로젝트의 문서 관리자입니다. 이 프로젝트는 Python 기반 한국주식 **데이트레이딩 자동매매 시스템**으로, 현재 Phase 2 진행 중 (1차 백테스트 FAIL → ADR-0019 복구 로드맵 Step F 가설 풀 확장 진입 중, ADR-0022 게이트 적용) + Phase 3 코드 산출물 완료 상태로 보존 단계입니다 (상세 상태는 root CLAUDE.md "현재 상태" 섹션에서 확인 — 이 에이전트 파일의 구체 산출물 나열에 의존하지 말 것).
 
 ## 프로젝트 컨텍스트
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 프로젝트 한 줄 요약
 
-Python 기반 한국주식 **데이트레이딩** 자동매매 시스템. 한국투자증권 KIS Developers API + Opening Range Breakout(ORB) 전략 + 100~200만원 초기 자본. **paper 주문 + live 시세 하이브리드 키** 구조 (KIS paper 도메인에 시세 API 없음 — 시세는 별도 실전 APP_KEY 로 실전 도메인 호출). 현재 **Phase 1 PASS (코드·테스트 레벨). Phase 2 진행 중 — 백테스트 엔진·전략·리스크·CSV/KIS 분봉 어댑터·백필 CLI 까지 모든 코드 산출물 완료. 2026-04-24 1차 백테스트 FAIL + 복구 로드맵 (A 민감도 → B 비용 → C 유니버스 → D 파라미터 → E 전략 교체) 순차 게이팅. Step A~E 전원 FAIL (230+ 런 / 0 PASS) → Step F (가설 풀 확장, ADR-0022 게이트 적용) 진입 중. Phase 3 코드 산출물 (Executor·main.py APScheduler·monitor/notifier·storage/db·세션 재기동·broker 체결조회) 모두 완료 상태로 보존 — 단 Phase 2 수익률 확인 전까지 Phase 3 진입 금지.**
+Python 기반 한국주식 **데이트레이딩** 자동매매 시스템. 한국투자증권 KIS Developers API + Opening Range Breakout(ORB) 전략 + 100~200만원 초기 자본. **paper 주문 + live 시세 하이브리드 키** 구조 (KIS paper 도메인에 시세 API 없음 — 시세는 별도 실전 APP_KEY 로 실전 도메인 호출). 현재 **Phase 1 PASS (코드·테스트 레벨). Phase 2 진행 중 — 백테스트 엔진·전략·리스크·CSV/KIS 분봉 어댑터·백필 CLI 까지 모든 코드 산출물 완료. 2026-04-24 1차 백테스트 FAIL + 복구 로드맵 (A 민감도 → B 비용 → C 유니버스 → D 파라미터 → E 전략 교체) 순차 게이팅. Step A~E 전원 FAIL (230+ 런 / 0 PASS) → Step F (가설 풀 확장, ADR-0022 게이트 적용) 진입 중 — PR1 (F1 DCA baseline) 완료, PASS (MDD -12.92% / Sharpe 2.27 / 총수익률 +51.50% mark-to-market). Phase 3 코드 산출물 (Executor·main.py APScheduler·monitor/notifier·storage/db·세션 재기동·broker 체결조회) 모두 완료 상태로 보존 — 단 Phase 2 수익률 확인 전까지 Phase 3 진입 금지.**
 
 상세 설계는 `plan.md`를 참조한다. 외부 독자용 개요는 `README.md`.
 
@@ -216,9 +216,9 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
 
 관련 자산: [.claude/hooks/src-first-requires-tests.sh](.claude/hooks/src-first-requires-tests.sh), [.claude/hooks/doc-sync-check.sh](.claude/hooks/doc-sync-check.sh), [.claude/agents/unit-test-writer.md](.claude/agents/unit-test-writer.md) 의 "TDD 모드 계약" 섹션, [docs/adr/0010-tdd-order-enforcement.md](./docs/adr/0010-tdd-order-enforcement.md).
 
-## 현재 상태 (2026-05-01 기준)
+## 현재 상태 (2026-05-02 기준)
 
-**한 줄 진행도**: Phase 1 PASS · Phase 2 진행 중 (1차 백테스트 FAIL → ADR-0019 복구 로드맵). Phase 3 코드 산출물 완료 상태로 보존, 진입 금지.
+**한 줄 진행도**: Phase 1 PASS · Phase 2 진행 중 (1차 백테스트 FAIL → ADR-0019 복구 로드맵 Step F PR1 PASS). Phase 3 코드 산출물 완료 상태로 보존, 진입 금지.
 
 - **Phase 2 1차 백테스트 결과 (2026-04-24, 1년치 KIS 백필 + `--loader=kis`)**: MDD **-51.36%**, 총수익률 -50.05%, 샤프 -6.81, 승률 31.35%, 손익비 1.28, 기대값 ≈ -0.28R. Phase 2 PASS 기준 3.4 배 초과 미달.
 - **신규 Phase 2 PASS 게이트 (ADR-0019)**: (1) MDD > -15%, (2) 승률 × 손익비 > 1.0, (3) 연환산 샤프 > 0 — 세 조건 전부 충족 + walk-forward 통과 후에만 Phase 3 착수.
@@ -236,8 +236,9 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
     - Gap-Reversal Top 100: MDD -19.99% · 승×손익비 0.289 · 샤프 -6.27 — FAIL.
     - 코드 산출물(`VWAPMRStrategy`·`GapReversalStrategy`·`DailyBarPrevCloseProvider`·`backfill_daily_bars`) 보존. 런북: `docs/runbooks/step_e_vwap_mr_2026-05-01.md` · `docs/runbooks/step_e_gap_reversal_2026-05-01.md`.
   - **Step F** — 가설 풀 확장 (ADR-0021 결정, ADR-0022 게이트 적용). 진입 중. 게이트 재정의: MDD > -25% · DCA baseline 대비 양의 알파 · 연환산 샤프 > 0.3 (세 조건 동시). 상세 진행 계획: `docs/step_f_strategy_pool_plan.md`.
+    - **PR1 (F1 DCA baseline) 완료 — PASS (2026-05-02)**. MDD -12.92% · Sharpe 2.2683 · 총수익률 +51.50% mark-to-market (시작 자본 2,000,000 KRW, KODEX 200 069500, 1년). 후속 PR (F2 Golden Cross 등) 진행 대기. 런북: `docs/runbooks/step_f_dca_baseline_2026-05-02.md`.
 - **Phase 3 진입 금지 (ADR-0019)**: 게이트 통과 전까지 `main.py` 모의투자 무중단 운영 계획 전면 보류. `execution/`·`main.py`·`monitor/`·`storage/` 코드 산출물은 보존 — 복구 후 그대로 재사용.
-- **테스트 카운트**: pytest **1670 collected** (Step E PR4 Stage 3 기준 — Stage 2 1651 + Stage 3 신규 19건: `test_backfill_daily_bars_cli.py` TestParseArgs 5 + TestRunPipeline 12 + TestMainExitCode 2).
+- **테스트 카운트**: pytest **1749 collected** (Step F PR1 기준 — Step E PR4 Stage 3 1670 + Step F PR1 신규 79건: `test_strategy_dca.py` 31 + `test_daily_bar_loader.py` 16 + `test_backtest_dca.py` 32).
 - **운영자 close 대기 Issue**: #51 (Phase 2 PASS 판정 FAIL → 복구 로드맵으로 대체) · #52 (`KisMinuteBarLoader` 파싱 실패 대응, 운영자 `scripts/debug_kis_minute.py` 실행 후 댓글) · #63 (공휴일 캘린더 가드, 백필 재실행으로 `date_mismatch` 0 확인 후 댓글) · #71 (장시간 hang 방지, 2026-04-24 백필 완주 확인 — 운영자 댓글만 잔여).
 
 상세한 Phase 별 산출물·결정·테스트 카운트 변화·Issue 대응 이력은 [docs/phase-history.md](./docs/phase-history.md) 참조.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ KOSPI 200 대형주를 대상으로 Opening Range Breakout(ORB) 전략을 자동
 
 **Step F 진입 (2026-05-01, ADR-0021·ADR-0022)** — 가설 풀 확장. 일중 데이트레이딩 가정 폐기 + 일/월 단위 전략 + DCA baseline 비교. ADR-0022 게이트 적용 (MDD > -25% · DCA 대비 양의 알파 · 연환산 샤프 > 0.3). 상세 진행 계획: [`docs/step_f_strategy_pool_plan.md`](./docs/step_f_strategy_pool_plan.md). 상세 설계와 각 Phase의 PASS 기준, 비용·위험 분석은 [`plan.md`](./plan.md)에 있습니다.
 
+**Step F PR1 (F1 DCA baseline) 완료 — PASS (2026-05-02)**. KODEX 200(069500) 월 정액 매수 DCA 전략 1년 백테스트. MDD -12.92% · 연환산 Sharpe 2.2683 · 총수익률 +51.50% mark-to-market. ADR-0022 게이트 1·3 PASS (게이트 2 N/A — 자기 자신 baseline). 후속 PR (F2 Golden Cross 등) 의 DCA 대비 알파 비교 기준 확정. 런북: `docs/runbooks/step_f_dca_baseline_2026-05-02.md`.
+
 **Phase 3 착수 전제 통과** (2026-04-21). 실전 시세 전용 APP_KEY 3종 발급·IP 화이트리스트 등록·평일 장중 `healthcheck.py` 4종 그린(WebSocket 체결 수신 OK) 완료.
 
 **Phase 3 첫 산출물 — Executor (코드·테스트 레벨) 완료** (2026-04-21). `execution/` 패키지 신설 — `Executor` + Protocol 3종(`OrderSubmitter`/`BalanceProvider`/`BarSource`) + 어댑터 3종(`LiveOrderSubmitter`/`LiveBalanceProvider`/`DryRunOrderSubmitter`) + `StepReport`/`ReconcileReport` DTO. pytest **605건 green**.

--- a/docs/runbooks/step_f_dca_baseline_2026-05-02.md
+++ b/docs/runbooks/step_f_dca_baseline_2026-05-02.md
@@ -1,0 +1,91 @@
+# Step F PR1 — F1 Buy & Hold DCA baseline (2026-05-02)
+
+> ADR-0019 Step F (가설 풀 확장) 첫 번째 PR. ADR-0022 게이트 적용.
+
+## 실행 명령
+
+```bash
+# 1. 일봉 캐시 백필 (idempotent)
+uv run python scripts/backfill_daily_bars.py --symbols 069500 --from 2025-04-22 --to 2026-04-21
+
+# 2. DCA 백테스트 실행
+uv run python scripts/backtest.py \
+  --strategy-type=dca \
+  --loader=daily \
+  --from=2025-04-22 \
+  --to=2026-04-21 \
+  --symbols=069500 \
+  --starting-capital=2000000 \
+  --monthly-investment=100000 \
+  --output-markdown=data/step_f_dca_baseline.md \
+  --output-csv=data/step_f_dca_baseline_metrics.csv \
+  --output-trades-csv=data/step_f_dca_baseline_trades.csv
+```
+
+## 결과
+
+| 항목 | 값 |
+|---|---|
+| 기간 | 2025-04-22 ~ 2026-04-21 (1년, 243 영업일) |
+| target_symbol | `069500` (KODEX 200) |
+| 시작 자본 | 2,000,000 KRW |
+| 월 투자금 | 100,000 KRW |
+| 매수 횟수 | 13 lots |
+| 총수익률 (mark-to-market) | **+51.50%** |
+| 최대 낙폭 (MDD) | **-12.92%** |
+| 샤프 비율 (연환산) | **2.2683** |
+| 승률 (lot 별 가상 청산) | 100.00% |
+| 순손익 | +1,029,944 KRW |
+| 종료 자본 | 3,029,944 KRW |
+
+## ADR-0022 게이트별 판정
+
+| 게이트 | 기준 | 결과 | 판정 |
+|---|---|---|---|
+| 게이트 1 (MDD) | MDD > -25% | -12.92% | **PASS** |
+| 게이트 2 (DCA 대비 알파) | baseline 대비 양의 알파 | N/A (자기 자신 baseline) | **N/A** |
+| 게이트 3 (Sharpe) | 연환산 Sharpe > 0.3 | 2.2683 | **PASS** |
+
+**종합 판정: PASS** (적용 가능 게이트 전원 통과)
+
+## 한계·주의
+
+- **단일 종목 단일 구간 1년 표본** — ADR-0017 의 240 영업일 기준은 충족하지만, 1년치만으로는 generalization 한계. 후속 PR (F2~F5) 비교 baseline 으로만 사용 권장.
+- **mark-to-market 기준 총수익률** — 슬리피지·세금 미반영. `TradeRecord.net_pnl_krw` 는 lot 별 가상 청산 비용 반영값.
+- **qty=1 양자화 영향** — 월 투자금 100k 대비 ETF 단가 55k~86k 로 매수마다 1~2주 단위. 더 큰 자본 + 월 투자금이면 정밀도 개선.
+- **2025-04~2026-04 KOSPI 200 강세 구간** 의 결과. 다른 시점 (음수 구간) 백테스트 시 PASS 보장 X.
+- `BacktestEngine` 우회 설계 — `compute_dca_baseline` 은 다중 lot 누적·mark-to-market 을 직접 처리하므로 단일 lot 가정 + force_close 가정을 전제한 `BacktestEngine` 과 수치가 다를 수 있음. 설계 사유는 `src/stock_agent/backtest/CLAUDE.md` 참조.
+
+## 후속 PR 인용 베이스
+
+F2~F5 의 게이트 2 (DCA 대비 알파) 비교 기준:
+
+- **+51.50% mark-to-market** (1년치, 시작 자본 2,000,000 KRW, 069500 KODEX 200, 2025-04-22 ~ 2026-04-21)
+- 후속 전략 평가 시 **동일 데이터 소스 + 동일 시작 자본 + 동일 기간** 유지 필수.
+
+## 코드 산출물
+
+| 모듈 | 경로 | 공개 심볼 |
+|---|---|---|
+| DCA 전략 | `src/stock_agent/strategy/dca.py` | `DCAStrategy`, `DCAConfig` |
+| 일봉 어댑터 | `src/stock_agent/data/daily_bar_loader.py` | `DailyBarLoader`, `DailyBarSource`, `KST` |
+| DCA 평가 함수 | `src/stock_agent/backtest/dca.py` | `DCABaselineConfig`, `compute_dca_baseline` |
+| CLI 라우팅 | `scripts/backtest.py` | `--strategy-type=dca`, `--loader=daily`, `--monthly-investment` |
+
+테스트 (신규 79건):
+
+| 파일 | 건수 |
+|---|---|
+| `tests/test_strategy_dca.py` | 31 |
+| `tests/test_daily_bar_loader.py` | 16 |
+| `tests/test_backtest_dca.py` | 32 |
+| 합계 | **79** |
+
+## 참조
+
+- ADR-0022 — Step F 게이트 재정의 (MDD > -25% · DCA 대비 알파 · Sharpe > 0.3)
+- ADR-0021 — Step E 폐기 + Step F 전환 결정
+- `docs/step_f_strategy_pool_plan.md` — Step F 전체 진행 계획
+- `src/stock_agent/strategy/CLAUDE.md` — DCAStrategy 상세
+- `src/stock_agent/data/CLAUDE.md` — DailyBarLoader 상세
+- `src/stock_agent/backtest/CLAUDE.md` — compute_dca_baseline 상세

--- a/docs/step_f_strategy_pool_plan.md
+++ b/docs/step_f_strategy_pool_plan.md
@@ -36,12 +36,15 @@ PR0 (본 PR — Step E close + Step F open)
   ├ docs/step_e_followup_plan.md 삭제
   ├ root CLAUDE.md / README.md / docs/adr/README.md 동기화
   ↓
-PR1 — F1 DCA baseline (선행 의존성)
-  ├ src/stock_agent/strategy/dca.py — DCAStrategy (월 1회 정액 매수)
-  ├ tests/test_strategy_dca.py
-  ├ scripts/backtest.py --strategy-type dca 라우팅
-  ├ docs/runbooks/step_f_dca_baseline_2026-MM-DD.md
-  ├ ADR-0022 게이트 판정 (PASS 예상 — 시장 평균 양수 가정)
+PR1 — F1 DCA baseline (선행 의존성) ✓ 완료 (2026-05-02, PASS)
+  ├ src/stock_agent/strategy/dca.py — DCAStrategy, DCAConfig
+  ├ src/stock_agent/data/daily_bar_loader.py — DailyBarLoader, DailyBarSource
+  ├ src/stock_agent/backtest/dca.py — DCABaselineConfig, compute_dca_baseline
+  ├ tests/test_strategy_dca.py (31건), tests/test_daily_bar_loader.py (16건), tests/test_backtest_dca.py (32건)
+  ├ scripts/backtest.py --strategy-type=dca, --loader=daily, --monthly-investment 라우팅
+  ├ docs/runbooks/step_f_dca_baseline_2026-05-02.md
+  ├ ADR-0022 게이트 판정: MDD -12.92% PASS / Sharpe 2.2683 PASS / DCA 알파 N/A → 종합 PASS
+  └ baseline 수치: 총수익률 +51.50% mark-to-market (시작 자본 2,000,000 KRW, 069500, 13 lots)
   ↓
 PR2 — F2 Golden Cross
   ├ src/stock_agent/strategy/golden_cross.py — GoldenCrossStrategy (200d SMA)
@@ -265,13 +268,12 @@ PR6 (종합 + ADR-0023)
 
 ## 다음 세션 시작 가이드
 
-1. 본 파일 읽기 → 현재 위치 파악 (`PR1 미시작` 상태에서 시작).
-2. 가장 작은 단위 (PR1 F1 DCA) 부터 RED-first TDD 사이클 시작:
-   - `tests/test_strategy_dca.py` 작성 (unit-test-writer 위임)
+1. 본 파일 읽기 → 현재 위치 파악 (`PR1 완료, PASS` 상태에서 시작).
+2. PR2 (F2 Golden Cross) 부터 RED-first TDD 사이클 시작:
+   - `tests/test_strategy_golden_cross.py` 작성 (unit-test-writer 위임)
    - FAIL 확인
-   - `src/stock_agent/strategy/dca.py` 구현
+   - `src/stock_agent/strategy/golden_cross.py` 구현
    - GREEN 확인
-   - `BarLoader` 일봉 어댑터 신설 (필요 시)
-   - `scripts/backtest.py --strategy-type dca` 라우팅 추가
-   - 백테스트 실행 + runbook 작성 + ADR-0022 게이트 판정
-3. PR1 머지 후 PR2~PR5 병렬 진행 가능.
+   - `scripts/backtest.py --strategy-type golden-cross` 라우팅 추가
+   - 백테스트 실행 + runbook 작성 + ADR-0022 게이트 판정 (DCA baseline +51.50% 대비 알파 포함)
+3. PR2~PR5 병렬 진행 가능 (서로 의존 X). DCA baseline 비교 기준: **+51.50% mark-to-market** (2025-04-22 ~ 2026-04-21, 시작 자본 2,000,000 KRW, 069500).

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -56,6 +56,7 @@ from stock_agent.backtest import (
     BacktestResult,
     TradeRecord,
 )
+from stock_agent.backtest.dca import DCABaselineConfig, compute_dca_baseline
 from stock_agent.backtest.loader import BarLoader
 from stock_agent.backtest.prev_close import DailyBarPrevCloseProvider
 from stock_agent.config import get_settings
@@ -69,7 +70,13 @@ from stock_agent.data import (
     YamlBusinessDayCalendar,
     load_kospi200_universe,
 )
+from stock_agent.data.daily_bar_loader import DailyBarLoader
 from stock_agent.strategy.factory import STRATEGY_CHOICES, build_strategy_factory
+
+# `--strategy-type` argparse choices — factory 의 STRATEGY_CHOICES (orb/vwap-mr/
+# gap-reversal) + "dca". DCA 는 BacktestEngine 우회 경로(`compute_dca_baseline`)
+# 라 factory 에 들어가지 않는다.
+_CLI_STRATEGY_CHOICES: tuple[str, ...] = (*STRATEGY_CHOICES, "dca")
 
 # exit code 규약 (scripts/sensitivity.py 와 동일): 2 = 입력·설정 오류 (재시도
 # 무의미), 3 = I/O 오류 (재시도 가치 있음).
@@ -87,12 +94,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--loader",
-        choices=["csv", "kis"],
+        choices=["csv", "kis", "daily"],
         default="csv",
         help=(
             "분봉 소스. csv=MinuteCsvBarLoader(--csv-dir 필수), "
             "kis=KisMinuteBarLoader(실전 APP_KEY 3종 + IP 화이트리스트 필요, "
-            "KIS 서버 최대 1년 보관)."
+            "KIS 서버 최대 1년 보관), "
+            "daily=DailyBarLoader(`HistoricalDataStore` 일봉 → 09:00 KST MinuteBar). "
+            "Step F 일/월 단위 가설 (DCA·Golden Cross 등) 평가용."
         ),
     )
     parser.add_argument(
@@ -140,12 +149,21 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--strategy-type",
         type=str,
         default="orb",
-        choices=STRATEGY_CHOICES,
+        choices=_CLI_STRATEGY_CHOICES,
         help=(
-            "전략 선택 (ADR-0019 Step E). orb=ORBStrategy(기본), "
-            "vwap-mr=VWAPMRStrategy, gap-reversal=GapReversalStrategy. "
-            "gap-reversal 은 Stage 2 prev_close_provider 통합 전까지 stub provider "
-            "폴백 — 진입 0 (회귀 안전망)."
+            "전략 선택. orb=ORBStrategy(기본), vwap-mr=VWAPMRStrategy, "
+            "gap-reversal=GapReversalStrategy (ADR-0019 Step E). "
+            "dca=DCABaselineStrategy (ADR-0019 Step F PR1 — `--loader=daily` 권장). "
+            "dca 는 `BacktestEngine` 우회·`compute_dca_baseline` 경로."
+        ),
+    )
+    parser.add_argument(
+        "--monthly-investment",
+        type=int,
+        default=100_000,
+        help=(
+            "DCA 월 투자금 (KRW). `--strategy-type=dca` 분기에서만 사용. "
+            "`starting_capital_krw` 이하여야 한다."
         ),
     )
     parser.add_argument(
@@ -249,10 +267,17 @@ def _build_loader(args: argparse.Namespace) -> BarLoader:
     `kis` 모드는 `get_settings()` 호출로 `.env` 실전 키를 로드해
     `KisMinuteBarLoader` 를 반환한다 (실전 키 미주입 시 생성자에서
     `KisMinuteBarLoadError` fail-fast).
+
+    `daily` 모드는 `HistoricalDataStore` (기본 `data/stock_agent.db`) 일봉을
+    09:00 KST MinuteBar 로 래핑한 `DailyBarLoader` 를 반환한다. DB 미백필 상태
+    이면 `fetch_daily_ohlcv` 가 pykrx 네트워크 호출 — 결정론 보장을 위해
+    `scripts/backfill_daily_bars.py` 선행 권장.
     """
     if args.loader == "kis":
         settings = get_settings()
         return KisMinuteBarLoader(settings)
+    if args.loader == "daily":
+        return DailyBarLoader(HistoricalDataStore())
     # csv: --csv-dir 은 _parse_args 단계에서 conditional required 통과 후.
     assert args.csv_dir is not None, "csv 모드에서 csv_dir 는 _parse_args 가 강제한다"
     return MinuteCsvBarLoader(args.csv_dir)
@@ -264,7 +289,13 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     엔진·로더 공개 API 만 호출. 경계를 single-purpose 로 분리해 `main()` 은
     예외 → exit code 매핑에 집중한다 (sensitivity 와 동일 기조). `KisMinuteBarLoader`
     는 SQLite 커넥션을 닫아야 하므로 `try/finally` 로 `close()` 호출.
+
+    `--strategy-type=dca` 분기는 BacktestEngine 우회 — `_run_dca_pipeline` 위임.
     """
+    if args.strategy_type == "dca":
+        _run_dca_pipeline(args)
+        return
+
     symbols = _resolve_symbols(args.symbols, args.universe_yaml)
     loader = _build_loader(args)
     prev_close_provider: DailyBarPrevCloseProvider | None = None
@@ -317,6 +348,191 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             symbol_count=len(symbols),
         ),
     )
+
+
+def _run_dca_pipeline(args: argparse.Namespace) -> None:
+    """`--strategy-type=dca` 전용 파이프라인 — `compute_dca_baseline` 호출.
+
+    BacktestEngine 우회. `--symbols` 미지정 시 기본 target_symbol="069500" 단일.
+    `--symbols` 명시 시 첫 번째 심볼을 target_symbol 로 사용 (DCA 는 단일 종목).
+    """
+    target_symbol = _resolve_dca_target_symbol(args.symbols)
+    loader = _build_loader(args)
+
+    config = DCABaselineConfig(
+        starting_capital_krw=args.starting_capital,
+        monthly_investment_krw=args.monthly_investment,
+        target_symbol=target_symbol,
+    )
+
+    logger.info(
+        "dca.start loader={l} from={s} to={e} target={t} capital={c} monthly={m}",
+        l=args.loader,
+        s=args.start,
+        e=args.end,
+        t=target_symbol,
+        c=args.starting_capital,
+        m=args.monthly_investment,
+    )
+
+    try:
+        result = compute_dca_baseline(loader, config, args.start, args.end)
+
+        context = _ReportContext(
+            start=args.start,
+            end=args.end,
+            symbols=(target_symbol,),
+            starting_capital_krw=args.starting_capital,
+        )
+
+        args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+        args.output_trades_csv.parent.mkdir(parents=True, exist_ok=True)
+
+        args.output_markdown.write_text(
+            _render_dca_markdown(
+                result,
+                context,
+                target_symbol=target_symbol,
+                monthly_investment_krw=args.monthly_investment,
+            ),
+            encoding="utf-8",
+        )
+        _write_metrics_csv(result.metrics, args.output_csv)
+        _write_trades_csv(result.trades, args.output_trades_csv)
+    finally:
+        close = getattr(loader, "close", None)
+        if callable(close):
+            close()
+
+    logger.info(
+        "dca.done trades={t} mdd={m} sharpe={s} verdict={v}",
+        t=len(result.trades),
+        m=_format_pct(result.metrics.max_drawdown_pct),
+        s=_format_decimal(result.metrics.sharpe_ratio, 4),
+        v=_dca_verdict_label(result.metrics, daily_equity_len=len(result.daily_equity)),
+    )
+
+
+def _resolve_dca_target_symbol(raw_symbols: str) -> str:
+    """`--symbols` 인자에서 DCA target_symbol 추출. 미지정 시 기본값 069500."""
+    parts: list[str] = [s.strip() for s in raw_symbols.split(",") if s.strip()]
+    if not parts:
+        return "069500"
+    first = parts[0]
+    if len(parts) > 1:
+        logger.warning(
+            "DCA 는 단일 심볼 — `--symbols={}` 중 첫 번째({})만 사용",
+            raw_symbols,
+            first,
+        )
+    return first
+
+
+# ADR-0022 Step F 게이트 — Step F 가설 풀 평가용 임계값.
+_DCA_MDD_THRESHOLD: Decimal = Decimal("-0.25")  # 게이트 1: MDD > -25%
+_DCA_SHARPE_THRESHOLD: Decimal = Decimal("0.3")  # 게이트 3: 연환산 Sharpe > 0.3
+_DCA_MIN_SESSIONS_FOR_PASS: int = 240  # ADR-0017 — 240 영업일 미만은 PASS 라벨 신뢰도 낮음.
+
+
+def _dca_verdict_label(metrics: BacktestMetrics, *, daily_equity_len: int) -> str:
+    """ADR-0022 게이트 1 + 게이트 3 동시 판정. 게이트 2 (DCA 대비 알파) 는 자기 자신 N/A.
+
+    게이트 1: `max_drawdown_pct > -0.25`.
+    게이트 3: `sharpe_ratio > 0.3` (240 영업일 이상 표본에서만 신뢰).
+
+    Args:
+        metrics: BacktestMetrics — `max_drawdown_pct`/`sharpe_ratio` 검사.
+        daily_equity_len: 영업일 수. 240 미만이면 caveat 라벨.
+
+    Returns:
+        "PASS" / "FAIL (게이트 1)" / "FAIL (게이트 3)" / "FAIL (게이트 1·3)" /
+        "PASS (참고용 — 표본 240 미만)" 형태.
+    """
+    gate1_pass = metrics.max_drawdown_pct > _DCA_MDD_THRESHOLD
+    gate3_pass = metrics.sharpe_ratio > _DCA_SHARPE_THRESHOLD
+    failed: list[str] = []
+    if not gate1_pass:
+        failed.append("게이트 1")
+    if not gate3_pass:
+        failed.append("게이트 3")
+    if failed:
+        return f"FAIL ({'·'.join(failed)})"
+    if daily_equity_len < _DCA_MIN_SESSIONS_FOR_PASS:
+        return "PASS (참고용 — 표본 240 미만)"
+    return "PASS"
+
+
+def _render_dca_markdown(
+    result: BacktestResult,
+    context: _ReportContext,
+    *,
+    target_symbol: str,
+    monthly_investment_krw: int,
+) -> str:
+    """DCA baseline 전용 Markdown 리포트 — ADR-0022 게이트 적용."""
+    metrics = result.metrics
+    verdict = _dca_verdict_label(metrics, daily_equity_len=len(result.daily_equity))
+    lines: list[str] = []
+
+    lines.append("# DCA Baseline 백테스트 리포트 (ADR-0019 Step F PR1)")
+    lines.append("")
+    lines.append(f"- 기간: `{context.start.isoformat()}` ~ `{context.end.isoformat()}`")
+    lines.append(f"- target_symbol: `{target_symbol}`")
+    lines.append(f"- 시작 자본: {context.starting_capital_krw:,} KRW")
+    lines.append(f"- 월 투자금: {monthly_investment_krw:,} KRW")
+    lines.append(f"- 매수 횟수 (lots): {len(result.trades)}")
+    lines.append("")
+    lines.append(f"## ADR-0022 게이트 판정: **{verdict}**")
+    lines.append("")
+    lines.append(
+        f"- 게이트 1 (MDD > {_format_pct(_DCA_MDD_THRESHOLD)}): "
+        f"`{_format_pct(metrics.max_drawdown_pct)}`"
+    )
+    lines.append("- 게이트 2 (DCA 대비 알파): **N/A** — 자기 자신이 baseline.")
+    lines.append(
+        f"- 게이트 3 (Sharpe > {_format_decimal(_DCA_SHARPE_THRESHOLD, 2)}): "
+        f"`{_format_decimal(metrics.sharpe_ratio, 4)}`"
+    )
+    lines.append("")
+    lines.append("## 메트릭")
+    lines.append("")
+    lines.append("| 항목 | 값 |")
+    lines.append("|---|---|")
+    lines.append(f"| 총수익률 (mark-to-market) | {_format_pct(metrics.total_return_pct)} |")
+    lines.append(f"| 최대 낙폭 (MDD) | {_format_pct(metrics.max_drawdown_pct)} |")
+    lines.append(f"| 샤프 비율 (연환산) | {_format_decimal(metrics.sharpe_ratio, 4)} |")
+    lines.append(f"| 승률 (lot 별 가상 청산) | {_format_pct(metrics.win_rate)} |")
+    lines.append(f"| 평균 손익비 | {_format_decimal(metrics.avg_pnl_ratio, 4)} |")
+    lines.append(f"| 순손익 (KRW, mark-to-market) | {metrics.net_pnl_krw:,} |")
+    lines.append("")
+    lines.append("## 일일 자본 요약")
+    lines.append("")
+    if result.daily_equity:
+        equities = [row.equity_krw for row in result.daily_equity]
+        first = result.daily_equity[0]
+        last = result.daily_equity[-1]
+        trough = min(result.daily_equity, key=lambda r: r.equity_krw)
+        lines.append(f"- 세션 수: {len(result.daily_equity)}")
+        lines.append(f"- 시작: `{first.session_date.isoformat()}` {first.equity_krw:,} KRW")
+        lines.append(f"- 종료: `{last.session_date.isoformat()}` {last.equity_krw:,} KRW")
+        lines.append(f"- 최저점: `{trough.session_date.isoformat()}` {trough.equity_krw:,} KRW")
+        lines.append(f"- 최고점 자본: {max(equities):,} KRW")
+    else:
+        lines.append("- 세션 없음 (입력 분봉이 비어있거나 날짜 필터 결과가 0건)")
+    lines.append("")
+    lines.append("## 주의")
+    lines.append("")
+    lines.append(
+        "- DCA 는 영구 보유 가정 — 본 리포트의 `total_return_pct` 는 mark-to-market "
+        "(슬리피지·세금 미반영). `TradeRecord.net_pnl_krw` 는 lot 별 가상 청산 비용 반영값 — "
+        "실제 청산 의도 없음."
+    )
+    lines.append(
+        "- 후속 PR (F2~F5) 의 알파 비교는 본 리포트의 `total_return_pct` 를 baseline 으로 사용."
+    )
+    lines.append("")
+    return "\n".join(lines)
 
 
 def _render_markdown(result: BacktestResult, context: _ReportContext) -> str:

--- a/src/stock_agent/backtest/CLAUDE.md
+++ b/src/stock_agent/backtest/CLAUDE.md
@@ -19,6 +19,10 @@ stock-agent 의 시뮬레이션 경계 모듈. `ORBStrategy` + `RiskManager` 를
 `generate_windows`, `run_walk_forward`,
 `DailyBarPrevCloseProvider`
 
+`dca.py` 공개 심볼 (`backtest/dca.py` — `__init__.py` 미재노출, 직접 import):
+
+`DCABaselineConfig`, `compute_dca_baseline`
+
 `RejectReason` 은 `stock_agent.risk` 의 Literal 을 재노출. `BacktestResult.rejected_counts` 의 키 타입이라 같은 패키지에서 접근 가능해야 소비자가 `risk` 패키지를 직접 import 하지 않는다.
 
 ## 현재 상태 (2026-04-20 기준)
@@ -246,6 +250,57 @@ uv run python scripts/sensitivity.py --loader=kis --from 2025-04-22 --to 2026-04
 관련 테스트: `tests/test_sensitivity_cli.py` (기존 + Step E PR4 `TestStrategyTypeFlag` 4 + `TestStrategyTypeBaseConfigRouting` 6 + Stage 2 `TestGapReversalPrevCloseProviderInjection` 8 신규 포함).
 
 exit code 규약: `0` 정상 / `2` 입력·설정 오류 (`MinuteCsvLoadError`, `RuntimeError`) / `3` I/O 오류 (`OSError`). 그 외 예외는 버그로 간주해 Python 기본 traceback 으로 전파. generic `except Exception` 폐기 — `_run_pipeline(args)` 로 파이프라인 분리 후 `main()` 은 예외 매핑만 담당.
+
+### `dca.py` — DCA Baseline 평가 함수 (Step F PR1)
+
+ADR-0019 Step F PR1 에서 도입. `DCAStrategy` 의 다중 lot 누적·mark-to-market 평가를 담당. `BacktestEngine` 을 우회해 별도 평가 함수로 구현.
+
+`backtest/__init__.py` 에 재노출하지 않음 — 소비자 `scripts/backtest.py` 가 직접 import.
+
+#### `DCABaselineConfig` (`@dataclass(frozen=True, slots=True)`)
+
+`BacktestConfig` 와 동일한 필드 구조 (`starting_capital_krw`, `commission_rate`, `slippage_rate`, `sell_tax_rate`) + `DCAConfig` 를 포함.
+
+`__post_init__` 검증 (위반 시 `RuntimeError`): 자본 양수, 비율 음수 금지.
+
+#### `compute_dca_baseline` 시그니처
+
+```python
+def compute_dca_baseline(
+    loader: BarLoader,
+    config: DCABaselineConfig,
+    start: date,
+    end: date,
+) -> BacktestResult:
+```
+
+**알고리즘** (다중 lot 누적·mark-to-market):
+1. `loader.stream(start, end, (config.dca_config.target_symbol,))` 로 일봉 스트림 수신.
+2. `DCAStrategy` 가 `EntrySignal` 을 반환하면 lot 매수 + 비용 처리.
+3. 루프 종료 시 전체 lot 가상 청산 (mark-to-market 기준 종가 체결).
+4. `BacktestResult` 반환 — `trades`, `daily_equity`, `metrics`, `rejected_counts`, `post_slippage_rejections`.
+
+**BacktestEngine 우회 사유**:
+- `BacktestEngine` 은 단일 lot 가정 + `force_close_at` 기반 청산 가정 전제 — DCA 다중 lot 누적 및 "계속 보유" 정책과 비호환.
+- `EntrySignal.stop_price=0 / take_price=0` 마커를 인식해 손익절 판정 건너뜀.
+
+**운영 주의**: `compute_dca_baseline` 의 총수익률은 mark-to-market 기준이며 슬리피지·세금은 lot 단위 가상 청산 시 반영. `BacktestEngine` 결과와 직접 비교 불가.
+
+#### 테스트 현황 (dca.py)
+
+pytest **32 케이스 green** (`tests/test_backtest_dca.py`). 외부 I/O 없음 — `InMemoryBarLoader` + 합성 일봉 fixture.
+
+| 그룹 | 내용 |
+|---|---|
+| Config 검증 | 자본 양수, 비율 음수 금지 |
+| 정상 실행 | 단일 lot·다중 lot·mark-to-market 수익률 검증 |
+| 비용 반영 | 수수료·슬리피지·매도세 lot 단위 적용 |
+| 빈 입력 | 신호 없음 → 빈 trades, 0 수익률 |
+| BacktestResult 계약 | metrics·daily_equity·rejected_counts 구조 |
+
+관련 테스트 파일: `tests/test_backtest_dca.py`.
+
+---
 
 ## 설계 원칙
 

--- a/src/stock_agent/backtest/dca.py
+++ b/src/stock_agent/backtest/dca.py
@@ -1,0 +1,358 @@
+"""DCA (Dollar-Cost Averaging) baseline 평가 함수.
+
+ADR-0019 Step F PR1 — F1 DCA baseline. KOSPI 200 ETF (069500 KODEX 200) 매월
+정해진 영업일에 정액 시장가 매수 + 영구 보유 시뮬레이션. ADR-0022 게이트 2
+(DCA baseline 대비 알파) 의 비교 기준 산출.
+
+설계 결정 — `BacktestEngine` 우회
+- `BacktestEngine` 은 단일 lot 가정 (`active[symbol]` 단일 키 + `_handle_entry`
+  덮어쓰기) + 매 세션 force_close 가정 (`_close_session` 이 잔존 active 잔여 시
+  `RuntimeError`) 이라 DCA (다중 lot 누적·영구 보유) 와 비호환. 별도 평가 함수
+  신설.
+- 결과는 동일 `BacktestResult` 형식으로 산출 — CLI · runbook · 메트릭 비교
+  파이프라인을 그대로 재사용.
+
+비용 계약 (`DCABaselineConfig` 기본값은 `BacktestConfig` 와 동일)
+- 슬리피지: 시장가 0.1% 불리 (매수 +방향, 매도 -방향).
+- 수수료: 매수·매도 대칭 0.015% (KIS 한투 비대면).
+- 거래세: 매도만 0.18% (KRX 2026-04).
+
+체결 흐름
+1. `DCAStrategy.on_bar` 가 매월 N 번째 영업일에 `EntrySignal` 1건 발생.
+2. `entry_fill = bar.close * (1 + slippage_rate)` 계산.
+3. `qty = int(monthly_investment_krw / entry_fill)` (floor). qty=0 → skip.
+4. `notional_dec = entry_fill * qty`, `buy_commission = int(notional * commission_rate)`.
+5. `total_cost = int(notional) + buy_commission` 가 `cash` 초과 → skip.
+6. 그 외: `cash -= total_cost`, lot 누적.
+
+Hypothetical 청산 (스트림 종료 후 1회)
+- DCA 는 영구 보유라 실제 청산 없음. 하지만 `BacktestResult.trades` 의 정합성
+  + ADR-0022 게이트 1 (MDD) 비교 합리성을 위해 마지막 close 기준 가상 청산
+  모델링.
+- `exit_fill = last_target_close * (1 - slippage_rate)`. 각 lot 별 `TradeRecord`
+  1건 (`exit_reason="force_close"`).
+- `BacktestMetrics.net_pnl_krw` 는 `ending - starting` (mark-to-market 기준,
+  슬리피지·세금 미반영). 거래별 손익은 `TradeRecord.net_pnl_krw` (실제 청산 비용
+  반영).
+
+DailyEquity
+- 세션 경계마다 `cash + sum(lot.qty) * last_close` 를 mark-to-market 기록.
+- 스트림 종료 시 마지막 세션 1건 추가 기록.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Final
+
+from loguru import logger
+
+from stock_agent.backtest import metrics as metrics_mod
+from stock_agent.backtest.engine import (
+    BacktestMetrics,
+    BacktestResult,
+    DailyEquity,
+    TradeRecord,
+)
+from stock_agent.backtest.loader import BarLoader
+from stock_agent.data import MinuteBar
+from stock_agent.strategy.base import EntrySignal
+from stock_agent.strategy.dca import DCAConfig, DCAStrategy
+
+_KST: Final = timezone(timedelta(hours=9))
+_SYMBOL_RE = re.compile(r"^\d{6}$")
+_PURCHASE_DAY_MAX = 28
+
+
+@dataclass(frozen=True, slots=True)
+class DCABaselineConfig:
+    """DCA baseline 백테스트 파라미터.
+
+    Raises:
+        RuntimeError: 자본·투자금 비양수, monthly > starting (첫 달 매수 불가),
+            symbol 정규식 위반, purchase_day 범위 [1, 28] 위반, 비율 음수,
+            slippage_rate `[0, 1)` 범위 위반.
+    """
+
+    starting_capital_krw: int
+    monthly_investment_krw: int
+    target_symbol: str = "069500"
+    purchase_day: int = 1
+    commission_rate: Decimal = Decimal("0.00015")
+    sell_tax_rate: Decimal = Decimal("0.0018")
+    slippage_rate: Decimal = Decimal("0.001")
+
+    def __post_init__(self) -> None:
+        if self.starting_capital_krw <= 0:
+            raise RuntimeError(
+                f"starting_capital_krw 는 양수여야 합니다 (got={self.starting_capital_krw})"
+            )
+        if self.monthly_investment_krw <= 0:
+            raise RuntimeError(
+                f"monthly_investment_krw 는 양수여야 합니다 (got={self.monthly_investment_krw})"
+            )
+        if self.monthly_investment_krw > self.starting_capital_krw:
+            raise RuntimeError(
+                f"monthly_investment_krw({self.monthly_investment_krw}) 는 "
+                f"starting_capital_krw({self.starting_capital_krw}) 이하여야 합니다 — "
+                "첫 달 매수 자체가 불가능."
+            )
+        if not _SYMBOL_RE.match(self.target_symbol):
+            raise RuntimeError(
+                f"target_symbol 은 6자리 숫자 문자열이어야 합니다 (got={self.target_symbol!r})"
+            )
+        if self.purchase_day < 1 or self.purchase_day > _PURCHASE_DAY_MAX:
+            raise RuntimeError(
+                f"purchase_day 는 [1, {_PURCHASE_DAY_MAX}] 범위여야 합니다 "
+                f"(got={self.purchase_day})"
+            )
+        if self.commission_rate < 0:
+            raise RuntimeError(
+                f"commission_rate 는 0 이상이어야 합니다 (got={self.commission_rate})"
+            )
+        if self.sell_tax_rate < 0:
+            raise RuntimeError(f"sell_tax_rate 는 0 이상이어야 합니다 (got={self.sell_tax_rate})")
+        if self.slippage_rate < 0 or self.slippage_rate >= 1:
+            raise RuntimeError(
+                f"slippage_rate 는 [0, 1) 범위여야 합니다 (got={self.slippage_rate})"
+            )
+
+
+@dataclass(slots=True)
+class _DCALot:
+    """DCA 누적 lot — 월별 매수 1건 단위."""
+
+    qty: int
+    entry_fill_price: Decimal
+    entry_ts: datetime
+    entry_notional_krw: int
+    buy_commission_krw: int
+
+
+def compute_dca_baseline(
+    loader: BarLoader,
+    config: DCABaselineConfig,
+    start: date,
+    end: date,
+) -> BacktestResult:
+    """DCA baseline 시뮬레이션 → BacktestResult.
+
+    `loader.stream(start, end, (target_symbol,))` 로 단일 심볼 분봉 스트림을
+    소비하고, `DCAStrategy` 가 발생시킨 `EntrySignal` 마다 매수 처리. 스트림
+    종료 후 마지막 close 기준 가상 청산으로 `TradeRecord` 생성.
+
+    Args:
+        loader: `BarLoader` Protocol 만족 — 보통 `DailyBarLoader` 를 일봉 경로로
+            주입. 멀티 심볼 분봉이어도 `target_symbol` 만 요청하므로 안전.
+        config: DCA 파라미터.
+        start, end: 백테스트 구간 (경계 포함).
+
+    Returns:
+        `BacktestResult` — `trades`, `daily_equity`, `metrics`. `rejected_counts`
+        은 항상 빈 dict, `post_slippage_rejections=0` (DCA 는 RiskManager 미사용).
+    """
+    dca_cfg = DCAConfig(
+        monthly_investment_krw=config.monthly_investment_krw,
+        target_symbol=config.target_symbol,
+        purchase_day=config.purchase_day,
+    )
+    strategy = DCAStrategy(dca_cfg)
+
+    cash: int = config.starting_capital_krw
+    lots: list[_DCALot] = []
+    daily_equity: list[DailyEquity] = []
+    last_session_date: date | None = None
+    last_target_close: Decimal | None = None
+    last_target_bar_time: datetime | None = None
+
+    def _equity_at(close_price: Decimal | None) -> int:
+        if close_price is None or not lots:
+            return cash
+        total_qty = sum(lot.qty for lot in lots)
+        return cash + int(close_price * Decimal(total_qty))
+
+    bars: Iterable[MinuteBar] = loader.stream(start, end, (config.target_symbol,))
+
+    for bar in bars:
+        bar_date = bar.bar_time.date()
+        if last_session_date is None:
+            last_session_date = bar_date
+        elif bar_date != last_session_date:
+            daily_equity.append(
+                DailyEquity(
+                    session_date=last_session_date,
+                    equity_krw=_equity_at(last_target_close),
+                )
+            )
+            last_session_date = bar_date
+
+        if bar.symbol == config.target_symbol:
+            last_target_close = bar.close
+            last_target_bar_time = bar.bar_time
+
+        signals = strategy.on_bar(bar)
+        for sig in signals:
+            if not isinstance(sig, EntrySignal):
+                continue  # DCAStrategy 는 ExitSignal 미생성 — defensive
+            cash, lot = _attempt_buy(cash, bar, sig, config)
+            if lot is not None:
+                lots.append(lot)
+
+    if last_session_date is not None:
+        daily_equity.append(
+            DailyEquity(
+                session_date=last_session_date,
+                equity_krw=_equity_at(last_target_close),
+            )
+        )
+
+    trades = _hypothetical_liquidation(
+        lots=lots,
+        last_target_close=last_target_close,
+        last_target_bar_time=last_target_bar_time,
+        config=config,
+    )
+
+    starting = config.starting_capital_krw
+    ending = daily_equity[-1].equity_krw if daily_equity else starting
+    metrics = _compute_metrics(
+        starting=starting,
+        ending=ending,
+        equity_series=[eq.equity_krw for eq in daily_equity],
+        net_pnls=[t.net_pnl_krw for t in trades],
+        trade_count=len(trades),
+        session_count=len(daily_equity),
+    )
+
+    return BacktestResult(
+        trades=tuple(trades),
+        daily_equity=tuple(daily_equity),
+        metrics=metrics,
+        rejected_counts={},
+        post_slippage_rejections=0,
+    )
+
+
+# ---- internal -----------------------------------------------------------
+
+
+def _attempt_buy(
+    cash: int,
+    bar: MinuteBar,
+    signal: EntrySignal,
+    config: DCABaselineConfig,
+) -> tuple[int, _DCALot | None]:
+    """단일 EntrySignal 처리. 매수 성공 시 (`new_cash`, lot), 실패 시 (`cash`, None)."""
+    entry_fill = bar.close * (Decimal("1") + config.slippage_rate)
+    if entry_fill <= 0:
+        logger.debug("DCA skip: entry_fill 비양수 ({})", entry_fill)
+        return cash, None
+
+    target_notional = Decimal(config.monthly_investment_krw)
+    qty = int(target_notional / entry_fill)
+    if qty <= 0:
+        logger.debug(
+            "DCA skip: monthly_investment 가 1주 단가 미만 (close={}, monthly={})",
+            bar.close,
+            config.monthly_investment_krw,
+        )
+        return cash, None
+
+    notional_dec = entry_fill * Decimal(qty)
+    notional_int = int(notional_dec)
+    buy_comm = int(notional_dec * config.commission_rate)
+    total_cost = notional_int + buy_comm
+    if total_cost > cash:
+        logger.debug(
+            "DCA skip: 잔액 부족 (need={}, have={})",
+            total_cost,
+            cash,
+        )
+        return cash, None
+
+    lot = _DCALot(
+        qty=qty,
+        entry_fill_price=entry_fill,
+        entry_ts=signal.ts,
+        entry_notional_krw=notional_int,
+        buy_commission_krw=buy_comm,
+    )
+    logger.info(
+        "DCA buy: {s} qty={q} entry={p} cost={c}",
+        s=signal.symbol,
+        q=qty,
+        p=entry_fill,
+        c=total_cost,
+    )
+    return cash - total_cost, lot
+
+
+def _hypothetical_liquidation(
+    *,
+    lots: list[_DCALot],
+    last_target_close: Decimal | None,
+    last_target_bar_time: datetime | None,
+    config: DCABaselineConfig,
+) -> list[TradeRecord]:
+    """스트림 종료 후 마지막 close 기준 가상 청산 → TradeRecord 리스트."""
+    if not lots or last_target_close is None or last_target_bar_time is None:
+        return []
+
+    exit_fill = last_target_close * (Decimal("1") - config.slippage_rate)
+    trades: list[TradeRecord] = []
+    for lot in lots:
+        exit_notional_dec = exit_fill * Decimal(lot.qty)
+        exit_notional_int = int(exit_notional_dec)
+        sell_comm = int(exit_notional_dec * config.commission_rate)
+        tax = int(exit_notional_dec * config.sell_tax_rate)
+        gross_pnl = exit_notional_int - lot.entry_notional_krw
+        commission_total = lot.buy_commission_krw + sell_comm
+        net_pnl = gross_pnl - commission_total - tax
+        trades.append(
+            TradeRecord(
+                symbol=config.target_symbol,
+                entry_ts=lot.entry_ts,
+                entry_price=lot.entry_fill_price,
+                exit_ts=last_target_bar_time,
+                exit_price=exit_fill,
+                qty=lot.qty,
+                exit_reason="force_close",
+                gross_pnl_krw=gross_pnl,
+                commission_krw=commission_total,
+                tax_krw=tax,
+                net_pnl_krw=net_pnl,
+            )
+        )
+    return trades
+
+
+def _compute_metrics(
+    *,
+    starting: int,
+    ending: int,
+    equity_series: list[int],
+    net_pnls: list[int],
+    trade_count: int,
+    session_count: int,
+) -> BacktestMetrics:
+    """`BacktestEngine._compute_metrics` 와 동일 계산 — 메트릭 형식 회귀 0."""
+    daily_returns: list[Decimal] = []
+    prev = starting
+    for eq in equity_series:
+        if prev > 0:
+            daily_returns.append(Decimal(eq - prev) / Decimal(prev))
+        prev = eq
+
+    return BacktestMetrics(
+        total_return_pct=metrics_mod.total_return_pct(starting, ending),
+        max_drawdown_pct=metrics_mod.max_drawdown_pct(equity_series),
+        sharpe_ratio=metrics_mod.sharpe_ratio(daily_returns),
+        win_rate=metrics_mod.win_rate(net_pnls),
+        avg_pnl_ratio=metrics_mod.avg_pnl_ratio(net_pnls),
+        trades_per_day=metrics_mod.trades_per_day(trade_count, session_count),
+        net_pnl_krw=ending - starting,
+    )

--- a/src/stock_agent/data/CLAUDE.md
+++ b/src/stock_agent/data/CLAUDE.md
@@ -17,7 +17,11 @@ YAML 로더, 실시간 분봉 소스를 한 자리에 모아 상위 레이어
 `BusinessDayCalendar`, `HolidayCalendar`, `HolidayCalendarError`, `YamlBusinessDayCalendar`, `load_kospi_holidays`,
 `SpreadSample`, `SpreadSampleCollector`, `SpreadSampleCollectorError`
 
-## 현재 상태 (2026-04-26 기준)
+`daily_bar_loader.py` 공개 심볼 (`data/daily_bar_loader.py` — `__init__.py` 미재노출, 직접 import):
+
+`DailyBarLoader`, `DailyBarSource`, `KST`
+
+## 현재 상태 (2026-05-02 기준)
 
 - **`historical.py`** — Phase 1 세 번째 산출물(축소판, v3)
   - 공개 API 1종: `fetch_daily_ohlcv(symbol, start, end)` + 보조 `close()` / 컨텍스트 매니저.
@@ -125,6 +129,67 @@ YAML 로더, 실시간 분봉 소스를 한 자리에 모아 상위 레이어
   - **CLI**: `scripts/collect_spread_samples.py` 가 본 어댑터를 사용해 평일 장중 호가를 JSONL 로 누적. ADR-0019 Step B 진행용 인프라.
   - **비스코프 (의도적 defer)**: WebSocket 호가 스트림 (Phase 5 후보) · 10단계 호가 전체 (`bidp2..bidp10`, `askp2..askp10`) — Step B 검증 목적상 1단계로 충분 · SQLite 캐시 — JSONL 누적이 분석 단순.
   - **의존성**: stdlib + python-kis 2.1.6. 추가 라이브러리 0.
+
+## `daily_bar_loader.py` — DailyBarLoader (Step F PR1)
+
+ADR-0019 Step F PR1 에서 도입. `HistoricalDataStore` 의 일봉을 `BarLoader` Protocol 을 만족하는 형태로 래핑한다. `DCAStrategy` 의 백테스트 입력 소스로 사용 (`--loader=daily`).
+
+`data/__init__.py` 에 재노출하지 않음 — 소비자 `scripts/backtest.py` 가 직접 import.
+
+### 공개 심볼
+
+| 심볼 | 타입 | 설명 |
+|---|---|---|
+| `DailyBarSource` | Protocol | `fetch_daily_ohlcv(symbol, start, end) -> list[DailyBar]` 계약. 테스트 fake double 호환 목적으로 분리. |
+| `KST` | `timezone` | `timezone(timedelta(hours=9))` — `strategy/base.py` 의 `KST` 와 값 동일, 교차 import 회피 목적 로컬 선언. |
+| `DailyBarLoader` | class | `BarLoader` Protocol 구현체. |
+
+### `DailyBarLoader`
+
+```python
+class DailyBarLoader:
+    def __init__(
+        self,
+        source: DailyBarSource,
+    ) -> None: ...
+
+    def stream(
+        self,
+        start: date,
+        end: date,
+        symbols: tuple[str, ...],
+    ) -> Iterable[MinuteBar]: ...
+
+    def close(self) -> None: ...
+    def __enter__(self) -> "DailyBarLoader": ...
+    def __exit__(self, *exc: object) -> None: ...
+```
+
+**의미론**: `DailyBarSource.fetch_daily_ohlcv` 결과를 날짜별 09:00 KST `MinuteBar` 로 래핑해 반환. `BarLoader` Protocol 계약(시간 단조증가·경계 포함 날짜 필터·심볼 필터) 충족.
+
+**입력 가드**:
+- `start > end` → `RuntimeError`
+- `symbols` 빈 tuple → `RuntimeError`
+- `symbol` 6자리 숫자 정규식 위반 → `RuntimeError`
+
+**라이프사이클**: `close()` 는 `source` 에 `close()` 메서드가 있으면 위임. 컨텍스트 매니저 지원.
+
+**재호출 안전**: 동일 `(start, end, symbols)` 로 `stream` 을 여러 번 호출하면 매번 새 Iterable 반환 — `BarLoader` Protocol 계약 준수.
+
+### 테스트 현황 (DailyBarLoader)
+
+pytest **16 케이스 green** (`tests/test_daily_bar_loader.py`). 외부 I/O 없음 — `DailyBarSource` fake double 주입.
+
+| 그룹 | 내용 |
+|---|---|
+| 정상 stream | 단일/다중 심볼, 날짜 필터, 빈 결과 |
+| MinuteBar 래핑 | 09:00 KST bar_time, OHLC 값, symbol 필드 |
+| 입력 가드 | start>end, 빈 symbols, 심볼 포맷 |
+| 라이프사이클 | close 위임, 컨텍스트 매니저 |
+
+관련 테스트 파일: `tests/test_daily_bar_loader.py`.
+
+---
 
 ## 설계 원칙
 

--- a/src/stock_agent/data/daily_bar_loader.py
+++ b/src/stock_agent/data/daily_bar_loader.py
@@ -1,0 +1,129 @@
+"""일봉 → MinuteBar(09:00 KST) 어댑터 — `BarLoader` Protocol 구현체.
+
+ADR-0019 Step F PR1 — F1 DCA baseline 의 일봉 입력 경로. `HistoricalDataStore`
+의 `fetch_daily_ohlcv` 결과 `DailyBar` 를 09:00 KST `MinuteBar` 로 래핑해
+`backtest/loader.py::BarLoader` 계약을 만족시킨다.
+
+설계 메모
+- 일봉을 MinuteBar 로 형변환하는 이유: 백테스트 엔진·전략 인터페이스가 모두
+  `MinuteBar` 를 일급 시계열 단위로 다루기 때문. 일/월 단위 가설 평가 (PR1
+  DCA · PR2 Golden Cross · PR3 모멘텀 등) 에서 분봉 어댑터 (`MinuteCsvBarLoader`,
+  `KisMinuteBarLoader`) 와 동일 시그니처로 plugin 가능.
+- bar_time = 09:00 KST 고정. 09:00 은 KRX 정규장 시작 시각으로, "이 영업일의
+  대표 시각" 으로 사용. 분봉 단위 분석을 하지 않으므로 다른 시각도 무방하나
+  09:00 이 가독성·외부 grep 면에서 가장 자연스럽다.
+- `daily_store` 는 호출자가 라이프사이클 관리. `close()` 는 위임만 한다.
+
+에러 정책 (broker/data 와 동일 기조)
+- `RuntimeError` 는 그대로 전파. 사전 가드: `start > end`, `symbols=()`.
+- store 에서 던진 예외는 래핑하지 않고 전파.
+- generic `except Exception` 미사용.
+
+스레드 모델
+- 단일 프로세스 전용 (`HistoricalDataStore` 와 동일).
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections.abc import Iterator
+from datetime import date, datetime, time, timedelta, timezone
+from types import TracebackType
+from typing import Protocol, Self
+
+from stock_agent.data.historical import DailyBar
+from stock_agent.data.realtime import MinuteBar
+
+KST = timezone(timedelta(hours=9))
+"""한국 표준시 (UTC+09:00). `strategy/base.py`·`data/realtime.py` 와 값 동일."""
+
+_BAR_TIME_OF_DAY = time(9, 0)
+
+
+class DailyBarSource(Protocol):
+    """일봉 소스 구조적 의존 — `HistoricalDataStore` 가 만족.
+
+    `DailyBarLoader` 는 SQLite·pykrx 에 직접 결합하지 않고 본 Protocol 만 의존.
+    테스트는 in-memory fake double 로 주입 가능 (`tests/test_daily_bar_loader.py`
+    의 `_FakeStore`). 운영 경로에서는 `HistoricalDataStore` 인스턴스를 그대로 주입.
+    """
+
+    def fetch_daily_ohlcv(self, symbol: str, start: date, end: date) -> list[DailyBar]: ...
+    def close(self) -> None: ...
+
+
+class DailyBarLoader:
+    """`DailyBarSource` 일봉을 `MinuteBar` 09:00 KST 로 래핑한 BarLoader.
+
+    `BarLoader` Protocol (`backtest/loader.py`) 충족. 매 영업일 1 건의 MinuteBar 를
+    `(bar_time, symbol)` 정렬 순서로 emit.
+
+    Args:
+        daily_store: `DailyBarSource` Protocol 을 만족하는 객체 — 운영에서는
+            `HistoricalDataStore`. 라이프사이클 관리는 호출자가 책임진다
+            (`close()` 는 위임만).
+    """
+
+    def __init__(self, daily_store: DailyBarSource) -> None:
+        self._daily_store = daily_store
+
+    def stream(
+        self,
+        start: date,
+        end: date,
+        symbols: tuple[str, ...],
+    ) -> Iterator[MinuteBar]:
+        """일봉을 MinuteBar 로 래핑해 시간순 yield.
+
+        Raises:
+            RuntimeError: `start > end` 또는 `symbols=()`. store 에서 던진
+                예외는 그대로 전파.
+        """
+        if start > end:
+            raise RuntimeError(
+                f"start({start.isoformat()}) 는 end({end.isoformat()}) 이전이어야 합니다."
+            )
+        if not symbols:
+            raise RuntimeError("symbols 는 1개 이상이어야 합니다.")
+
+        per_symbol_streams: list[Iterator[MinuteBar]] = []
+        for symbol in symbols:
+            daily_bars = self._daily_store.fetch_daily_ohlcv(symbol, start, end)
+            per_symbol_streams.append(self._wrap(symbol, daily_bars))
+
+        # heapq.merge 로 (bar_time, symbol) 단조증가 보장.
+        yield from heapq.merge(*per_symbol_streams, key=lambda b: (b.bar_time, b.symbol))
+
+    @staticmethod
+    def _wrap(symbol: str, daily_bars: list[DailyBar]) -> Iterator[MinuteBar]:
+        """단일 심볼의 DailyBar 리스트를 MinuteBar Iterator 로 변환.
+
+        호출자(`stream`) 가 이미 `fetch_daily_ohlcv` 결과를 받아왔으므로 입력은
+        이미 trade_date 정렬되어 있다 (`historical.py` 가 ORDER BY 보장). 여기서는
+        형변환만 수행.
+        """
+        for db in daily_bars:
+            yield MinuteBar(
+                symbol=symbol,
+                bar_time=datetime.combine(db.trade_date, _BAR_TIME_OF_DAY, tzinfo=KST),
+                open=db.open,
+                high=db.high,
+                low=db.low,
+                close=db.close,
+                volume=db.volume,
+            )
+
+    def close(self) -> None:
+        """`daily_store.close()` 위임. 멱등성은 store 책임."""
+        self._daily_store.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/src/stock_agent/strategy/CLAUDE.md
+++ b/src/stock_agent/strategy/CLAUDE.md
@@ -14,9 +14,13 @@ stock-agent 의 전략 경계 모듈. `Strategy` Protocol + `ORBStrategy` / `VWA
 
 `STRATEGY_CHOICES`, `StrategyType`, `build_strategy_factory`
 
-## 현재 상태 (2026-05-01 기준)
+`dca.py` 공개 심볼 (`strategy/dca.py` — `__init__.py` 미재노출, 직접 import):
 
-**Phase 2 진행 중. ORBStrategy 완료 (2026-04-20). VWAPMRStrategy 추가 (2026-05-01, Step E PR2 — ORB 폐기 후보 평가 첫 번째 전략, 백테스트 결과 대기 중). GapReversalStrategy 추가 (2026-05-01, Step E PR3 — ORB 폐기 후보 평가 두 번째 전략, 백테스트 결과 대기 중). `factory.py` 추가 (2026-05-01, Step E PR4 Stage 1 — `build_strategy_factory` + `--strategy-type` CLI 통합).**
+`DCAConfig`, `DCAStrategy`
+
+## 현재 상태 (2026-05-02 기준)
+
+**Phase 2 진행 중. ORBStrategy 완료 (2026-04-20). VWAPMRStrategy 추가 (2026-05-01, Step E PR2). GapReversalStrategy 추가 (2026-05-01, Step E PR3). `factory.py` 추가 (2026-05-01, Step E PR4 Stage 1). DCAStrategy 추가 (2026-05-02, Step F PR1 — ADR-0022 게이트 PASS).**
 
 ### `base.py` — Protocol + DTO + 상수
 
@@ -376,3 +380,53 @@ def build_strategy_factory(
 pytest **33 케이스 green** (`tests/test_strategy_factory.py`). 외부 목킹 불필요 — 순수 팩토리 로직.
 
 관련 테스트 파일: `tests/test_strategy_factory.py`.
+
+---
+
+## `dca.py` — DCAStrategy (Step F PR1)
+
+ADR-0019 Step F 복구 로드맵 첫 번째 전략 후보. ADR-0022 게이트 비교 기준 (baseline) 산출 목적으로 도입 (PR1, 2026-05-02). ADR-0022 게이트 판정: PASS.
+
+`strategy/__init__.py` 에 재노출하지 않음 — 소비자 `compute_dca_baseline` (`backtest/dca.py`) 이 직접 import.
+
+### `DCAConfig` (`@dataclass(frozen=True, slots=True)`)
+
+| 필드 | 기본값 | 설명 |
+|---|---|---|
+| `monthly_investment_krw` | 필수 | 월 투자금 (KRW 정수, 양수 필수) |
+| `target_symbol` | `"069500"` | 매수 대상 종목코드 (6자리 숫자, KODEX 200 기본) |
+| `purchase_day` | `1` | 영업일 기준 N번째 분봉 도달 시 매수 (1~28, 기본 1) |
+
+`__post_init__` 검증 (위반 시 `RuntimeError` — 다른 모듈과 동일 기조):
+- `monthly_investment_krw > 0`
+- `target_symbol` 6자리 숫자 정규식 (`^\d{6}$`)
+- `1 <= purchase_day <= 28`
+
+### `DCAStrategy` — 월 정액 매수 전략
+
+- `Strategy` Protocol 구현체 (`on_bar`, `on_time`).
+- **의미론**: `on_bar` 에서 `target_symbol` 의 `purchase_day` 번째 분봉 도달 시 `EntrySignal(stop_price=Decimal("0"), take_price=Decimal("0"))` 반환 — 손익절 미사용 마커 (force_close 없음).
+- `on_time` 은 항상 빈 리스트 반환 — 강제청산 없음.
+- **1일 1회 진입**: 당일 진입 후 추가 시그널 없음.
+- **영업일 캘린더 의존 없음**: 진입 조건이 분봉 수신 자체이므로 캘린더 불필요.
+- **세션 경계 자동 리셋**: `bar.bar_time.date()` 변경 감지 시 당일 진입 플래그 초기화.
+- **입력 검증 (`RuntimeError` 전파)**: aware datetime 강제 (naive → 거부).
+
+### 설계 특성
+
+- `stop_price=Decimal("0")` / `take_price=Decimal("0")` 는 "손익절 미사용" 마커 — `compute_dca_baseline` 이 이 값을 인식해 손익절 판정을 건너뛴다. `BacktestEngine` 에 직접 주입하면 비정상 동작하므로 `compute_dca_baseline` 경유가 필수.
+- 다중 lot 누적·mark-to-market 평가는 `backtest/dca.py` 의 `compute_dca_baseline` 이 담당 (`BacktestEngine` 우회).
+
+### 테스트 현황 (DCAStrategy)
+
+pytest **31 케이스 green** (`tests/test_strategy_dca.py`). 외부 목킹 불필요 — 순수 로직.
+
+| 그룹 | 내용 |
+|---|---|
+| Config 검증 | 양수 투자금·심볼 정규식·purchase_day 1~28 범위 |
+| 진입 시그널 | purchase_day 번째 분봉에서 1회 진입, 이후 당일 추가 시그널 없음 |
+| 청산 시그널 | on_time 빈 리스트, on_bar 청산 시그널 없음 |
+| 세션 전환 | 날짜 변경 시 플래그 리셋, 새 세션 재진입 허용 |
+| 입력 검증 | naive datetime 거부 |
+
+관련 테스트 파일: `tests/test_strategy_dca.py`.

--- a/src/stock_agent/strategy/dca.py
+++ b/src/stock_agent/strategy/dca.py
@@ -1,0 +1,164 @@
+"""Buy-and-hold DCA (Dollar-Cost Averaging) 전략 구현.
+
+ADR-0019 Step F PR1 — F1 Buy & Hold baseline. KOSPI 200 ETF (069500 KODEX 200)
+단일 종목에 대해 매월 정해진 영업일에 정액 시장가 매수, 청산 X 영구 보유.
+ADR-0022 게이트 2 (DCA baseline 대비 알파) 의 비교 기준 산출 목적.
+
+책임 범위
+- 매월 N번째 target_symbol 분봉 수신 시 `EntrySignal` 1건 방출.
+- 청산 시그널 절대 미생성 — DCA 는 영구 보유.
+- `on_time(now)` 항상 빈 리스트 — force_close 없음.
+
+설계 메모
+- 영업일 캘린더 의존 X. '받은 분봉 = 영업일' 가정 (`DailyBarLoader` 가 영업일만
+  공급) → 휴일은 분봉 미수신으로 자연스럽게 스킵된다.
+- 단일 `target_symbol` 카운팅. 비타겟 심볼 분봉은 조용히 무시 — 멀티 심볼
+  스트림에 안전.
+- `EntrySignal.stop_price` / `take_price` = `Decimal("0")` 마커. DCA 손익절
+  미사용을 호출자(`compute_dca_baseline`) 가 0 으로 인지.
+
+에러 정책 (broker/data/strategy 와 동일 기조)
+- `RuntimeError` 는 전파 — 잘못된 symbol·naive datetime·시간 역행·설정 위반.
+
+스레드 모델
+- 단일 프로세스 전용 (ORB·VWAPMR·GapReversal 와 동일).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from loguru import logger
+
+from stock_agent.data import MinuteBar
+from stock_agent.strategy.base import EntrySignal, Signal
+
+_SYMBOL_RE = re.compile(r"^\d{6}$")
+
+_DEFAULT_MONTHLY_INVESTMENT_KRW = 100_000
+_DEFAULT_TARGET_SYMBOL = "069500"
+_DEFAULT_PURCHASE_DAY = 1
+_PURCHASE_DAY_MAX = 28  # 모든 달에 N 번째 영업일 존재 보장 한계.
+
+
+@dataclass(frozen=True, slots=True)
+class DCAConfig:
+    """DCA 파라미터.
+
+    Raises:
+        RuntimeError: `monthly_investment_krw <= 0`,
+            `target_symbol` 이 6 자리 숫자 정규식 위반,
+            `purchase_day` 가 [1, 28] 범위를 벗어날 때.
+    """
+
+    monthly_investment_krw: int = _DEFAULT_MONTHLY_INVESTMENT_KRW
+    target_symbol: str = _DEFAULT_TARGET_SYMBOL
+    purchase_day: int = _DEFAULT_PURCHASE_DAY
+
+    def __post_init__(self) -> None:
+        if self.monthly_investment_krw <= 0:
+            raise RuntimeError(
+                f"monthly_investment_krw 는 양수여야 합니다 (got={self.monthly_investment_krw})"
+            )
+        if not _SYMBOL_RE.match(self.target_symbol):
+            raise RuntimeError(
+                f"target_symbol 은 6자리 숫자 문자열이어야 합니다 (got={self.target_symbol!r})"
+            )
+        if self.purchase_day < 1 or self.purchase_day > _PURCHASE_DAY_MAX:
+            raise RuntimeError(
+                f"purchase_day 는 [1, {_PURCHASE_DAY_MAX}] 범위여야 합니다 "
+                f"(got={self.purchase_day})"
+            )
+
+
+@dataclass
+class _DCAState:
+    """DCA 내부 상태. 월 경계마다 카운터·진입 플래그 리셋."""
+
+    last_bar_time: datetime | None = None
+    current_year_month: tuple[int, int] | None = None
+    counter: int = 0
+    entered_this_month: bool = False
+
+
+class DCAStrategy:
+    """매월 N 번째 영업일 정액 매수 + 영구 보유. `Strategy` Protocol 구현체.
+
+    공개 API: `on_bar`, `on_time`, `config` (프로퍼티).
+
+    동일 호출자 스레드 순차 호출 가정. 동시 호출 미지원.
+    """
+
+    def __init__(self, config: DCAConfig | None = None) -> None:
+        self._config = config if config is not None else DCAConfig()
+        self._state = _DCAState()
+
+    @property
+    def config(self) -> DCAConfig:
+        return self._config
+
+    def on_bar(self, bar: MinuteBar) -> list[Signal]:
+        """분봉 이벤트 진입점. target_symbol 의 N 번째 분봉에서 EntrySignal 1건."""
+        self._validate_symbol(bar.symbol)
+        self._require_aware(bar.bar_time, "bar.bar_time")
+
+        if self._state.last_bar_time is not None and bar.bar_time < self._state.last_bar_time:
+            raise RuntimeError(
+                f"bar.bar_time 역행 감지: last={self._state.last_bar_time.isoformat()}, "
+                f"now={bar.bar_time.isoformat()}"
+            )
+        self._state.last_bar_time = bar.bar_time
+
+        if bar.symbol != self._config.target_symbol:
+            return []
+
+        ym = (bar.bar_time.year, bar.bar_time.month)
+        if self._state.current_year_month != ym:
+            self._state.current_year_month = ym
+            self._state.counter = 0
+            self._state.entered_this_month = False
+
+        self._state.counter += 1
+
+        if self._state.entered_this_month:
+            return []
+        if self._state.counter < self._config.purchase_day:
+            return []
+
+        self._state.entered_this_month = True
+        signal = EntrySignal(
+            symbol=bar.symbol,
+            price=bar.close,
+            ts=bar.bar_time,
+            stop_price=Decimal("0"),
+            take_price=Decimal("0"),
+        )
+        logger.info(
+            "DCA 진입: {s} @ {p} (ts={t}, monthly_krw={k}, day_n={d})",
+            s=bar.symbol,
+            p=bar.close,
+            t=bar.bar_time.isoformat(),
+            k=self._config.monthly_investment_krw,
+            d=self._state.counter,
+        )
+        return [signal]
+
+    def on_time(self, now: datetime) -> list[Signal]:
+        """시각 이벤트 — DCA 는 force_close 없음, 항상 빈 리스트."""
+        self._require_aware(now, "now")
+        return []
+
+    @staticmethod
+    def _validate_symbol(symbol: str) -> None:
+        if not symbol or not _SYMBOL_RE.match(symbol):
+            raise RuntimeError(f"symbol 은 6자리 숫자 문자열이어야 합니다 (got={symbol!r})")
+
+    @staticmethod
+    def _require_aware(ts: datetime, name: str) -> None:
+        if ts.tzinfo is None:
+            raise RuntimeError(
+                f"{name} 은 tz-aware datetime 이어야 합니다 (got naive {ts.isoformat()})"
+            )

--- a/tests/test_backtest_dca.py
+++ b/tests/test_backtest_dca.py
@@ -1,0 +1,520 @@
+"""DCABaselineConfig DTO 가드 + compute_dca_baseline 동작 계약 검증.
+
+src/stock_agent/backtest/dca.py 의 두 공개 심볼
+  - DCABaselineConfig  : __post_init__ 검증 (RuntimeError 전파)
+  - compute_dca_baseline : BarLoader + DCAStrategy 를 엮어 BacktestResult 반환
+이 아직 존재하지 않는 상태에서 작성된 RED 테스트들이다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# --------------------------------------------------------------------------
+# 대상 모듈 임포트 — 미존재 시 ImportError 로 FAIL (RED 의도)
+# --------------------------------------------------------------------------
+from stock_agent.backtest.dca import DCABaselineConfig, compute_dca_baseline  # noqa: E402
+from stock_agent.backtest.loader import InMemoryBarLoader
+from stock_agent.data import MinuteBar
+
+# --------------------------------------------------------------------------
+# 공통 헬퍼
+# --------------------------------------------------------------------------
+
+KST = timezone(timedelta(hours=9))
+
+
+def _kst(d: date, h: int = 9, m: int = 0) -> datetime:
+    """date + h:m 을 KST tz-aware datetime 으로 반환."""
+    return datetime(d.year, d.month, d.day, h, m, tzinfo=KST)
+
+
+def _make_bar(
+    symbol: str,
+    bar_time: datetime,
+    close: int | str | Decimal,
+) -> MinuteBar:
+    """open=high=low=close 단순화된 MinuteBar 빌더."""
+    c = Decimal(str(close))
+    return MinuteBar(
+        symbol=symbol,
+        bar_time=bar_time,
+        open=c,
+        high=c,
+        low=c,
+        close=c,
+        volume=1000,
+    )
+
+
+# ===========================================================================
+# A. DCABaselineConfig DTO 가드
+# ===========================================================================
+
+
+class TestDCABaselineConfig:
+    """DCABaselineConfig __post_init__ 검증 — 모든 위반 조건은 RuntimeError."""
+
+    def test_정상_생성(self):
+        cfg = DCABaselineConfig(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+        )
+        assert cfg.starting_capital_krw == 1_000_000
+        assert cfg.target_symbol == "069500"
+        assert cfg.purchase_day == 1
+
+    def test_starting_capital_zero_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=0,
+                monthly_investment_krw=100_000,
+            )
+
+    def test_starting_capital_음수_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=-1,
+                monthly_investment_krw=100_000,
+            )
+
+    def test_monthly_investment_zero_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=0,
+            )
+
+    def test_monthly_investment_초과_RuntimeError(self):
+        """monthly_investment_krw > starting_capital_krw → 첫 달 매수 불가."""
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=100_000,
+                monthly_investment_krw=200_000,
+            )
+
+    def test_target_symbol_형식_위반_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                target_symbol="ABC",
+            )
+
+    @pytest.mark.parametrize(
+        "day",
+        [0, 29],
+        ids=["purchase_day=0", "purchase_day=29"],
+    )
+    def test_purchase_day_범위_위반_RuntimeError(self, day: int):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                purchase_day=day,
+            )
+
+    def test_slippage_rate_ge_1_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                slippage_rate=Decimal("1.0"),
+            )
+
+    def test_slippage_rate_음수_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                slippage_rate=Decimal("-0.1"),
+            )
+
+    def test_commission_rate_음수_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                commission_rate=Decimal("-0.001"),
+            )
+
+    def test_sell_tax_rate_음수_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCABaselineConfig(
+                starting_capital_krw=1_000_000,
+                monthly_investment_krw=100_000,
+                sell_tax_rate=Decimal("-0.001"),
+            )
+
+    def test_frozen_필드_수정_FrozenInstanceError(self):
+        cfg = DCABaselineConfig(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+        )
+        with pytest.raises(FrozenInstanceError):
+            cfg.starting_capital_krw = 2_000_000  # type: ignore[misc]
+
+
+# ===========================================================================
+# B. compute_dca_baseline — 단일 월 매수
+# ===========================================================================
+
+_D1 = date(2025, 1, 2)  # 2025-01-02 (첫째 영업일)
+_SYMBOL = "069500"
+
+
+class TestComputeDCABaselineSingleMonth:
+    """단일 월 분봉 1건 → 1 lot 매수 + 1 TradeRecord + daily_equity 1건."""
+
+    def _cfg(self, **kw) -> DCABaselineConfig:
+        defaults: dict[str, Any] = dict(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+            target_symbol=_SYMBOL,
+            purchase_day=1,
+            commission_rate=Decimal("0.00015"),
+            sell_tax_rate=Decimal("0.0018"),
+            slippage_rate=Decimal("0.001"),
+        )
+        defaults.update(kw)
+        return DCABaselineConfig(**defaults)
+
+    def test_1lot_매수_1TradeRecord(self):
+        """purchase_day=1, 분봉 1건 → 체결 1건."""
+        cfg = self._cfg()
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=10_000)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert len(result.trades) == 1
+
+    def test_entry_price_슬리피지_반영(self):
+        """entry_price = close * (1 + slippage_rate)."""
+        cfg = self._cfg(slippage_rate=Decimal("0.001"))
+        close = Decimal("10000")
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=close)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        expected_entry = close * (1 + Decimal("0.001"))
+        assert result.trades[0].entry_price == pytest.approx(float(expected_entry), rel=1e-9)
+
+    def test_exit_price_슬리피지_반영(self):
+        """hypothetical 청산: exit_price = last_close * (1 - slippage_rate)."""
+        cfg = self._cfg(slippage_rate=Decimal("0.001"))
+        close = Decimal("10000")
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=close)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        expected_exit = close * (1 - Decimal("0.001"))
+        assert result.trades[0].exit_price == pytest.approx(float(expected_exit), rel=1e-9)
+
+    def test_qty_floor_계산(self):
+        """qty = floor(monthly_investment_krw / entry_fill)."""
+        cfg = self._cfg(monthly_investment_krw=100_000, slippage_rate=Decimal("0"))
+        close = Decimal("3000")  # entry_fill = 3000, qty = floor(100000/3000) = 33
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=close)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert result.trades[0].qty == 33
+
+    def test_cash_감소_검증(self):
+        """매수 후 daily_equity.equity_krw < starting_capital_krw."""
+        cfg = self._cfg()
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=10_000)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert len(result.daily_equity) >= 1
+        # DCA 는 영구 보유 → equity = cash + mark-to-market
+        # 매수 후이므로 cash < starting_capital
+        initial = cfg.starting_capital_krw
+        # daily_equity 는 mark-to-market 포함이므로 단순 비교는 불가;
+        # 대신 trades 가 생겼으므로 TradeRecord 가 존재하는지 확인
+        assert len(result.trades) == 1
+        assert result.daily_equity[0].equity_krw <= initial
+
+    def test_exit_reason_force_close(self):
+        """hypothetical 청산의 exit_reason = 'force_close'."""
+        cfg = self._cfg()
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=10_000)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert result.trades[0].exit_reason == "force_close"
+
+
+# ===========================================================================
+# C. compute_dca_baseline — 다중 월 누적
+# ===========================================================================
+
+_D_JAN = date(2025, 1, 2)
+_D_FEB = date(2025, 2, 3)
+_D_MAR = date(2025, 3, 3)
+
+
+class TestComputeDCABaselineMultiMonth:
+    """3개월 첫 영업일 각각 매수 → 3 lots, 3 TradeRecord."""
+
+    def _cfg(self, **kw) -> DCABaselineConfig:
+        defaults: dict[str, Any] = dict(
+            starting_capital_krw=2_000_000,
+            monthly_investment_krw=200_000,
+            target_symbol=_SYMBOL,
+            purchase_day=1,
+            slippage_rate=Decimal("0"),
+            commission_rate=Decimal("0"),
+            sell_tax_rate=Decimal("0"),
+        )
+        defaults.update(kw)
+        return DCABaselineConfig(**defaults)
+
+    def _three_month_bars(
+        self,
+        close_jan: int = 10_000,
+        close_feb: int = 11_000,
+        close_mar: int = 12_000,
+    ) -> list[MinuteBar]:
+        return [
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 0), close=close_jan),
+            _make_bar(_SYMBOL, _kst(_D_FEB, 9, 0), close=close_feb),
+            _make_bar(_SYMBOL, _kst(_D_MAR, 9, 0), close=close_mar),
+        ]
+
+    def test_3trades_반환(self):
+        cfg = self._cfg()
+        bars = self._three_month_bars()
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_MAR)
+
+        assert len(result.trades) == 3
+
+    def test_각_월_매수가격_다름(self):
+        """가격이 다른 달에는 entry_price 가 각각 다름."""
+        cfg = self._cfg()
+        bars = self._three_month_bars(10_000, 11_000, 12_000)
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_MAR)
+
+        prices = [float(t.entry_price) for t in result.trades]
+        assert len(set(prices)) == 3, "세 달 진입가가 모두 달라야 한다"
+
+    def test_마지막_close_기준_hypothetical_청산(self):
+        """모든 lot 의 exit_price 는 마지막 bar.close 기준이어야 한다."""
+        cfg = self._cfg()
+        bars = self._three_month_bars(10_000, 11_000, 12_000)
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_MAR)
+
+        last_close = Decimal("12000")
+        for trade in result.trades:
+            assert trade.exit_price == pytest.approx(float(last_close), rel=1e-9)
+
+    def test_daily_equity_최소_3건(self):
+        """3개 세션이 있으면 daily_equity 도 3건 이상."""
+        cfg = self._cfg()
+        bars = self._three_month_bars()
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_MAR)
+
+        assert len(result.daily_equity) >= 3
+
+
+# ===========================================================================
+# D. compute_dca_baseline — 엣지 케이스
+# ===========================================================================
+
+
+class TestComputeDCABaselineEdgeCases:
+    """빈 스트림·qty=0·cash 고갈 케이스."""
+
+    def _cfg(self, **kw) -> DCABaselineConfig:
+        defaults: dict[str, Any] = dict(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+            target_symbol=_SYMBOL,
+            purchase_day=1,
+            slippage_rate=Decimal("0"),
+            commission_rate=Decimal("0"),
+            sell_tax_rate=Decimal("0"),
+        )
+        defaults.update(kw)
+        return DCABaselineConfig(**defaults)
+
+    def test_빈_bar_stream(self):
+        """bar 없으면 trades=(), daily_equity=() 반환."""
+        cfg = self._cfg()
+        loader = InMemoryBarLoader([])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert result.trades == ()
+        assert result.daily_equity == ()
+        assert result.metrics.net_pnl_krw == 0
+
+    def test_qty_zero_매수_skip(self):
+        """monthly < 1주 가격 → qty=0 → 매수 skip, trades=()."""
+        # close=200_000, monthly=100_000 → qty=floor(100000/200000)=0
+        cfg = self._cfg(monthly_investment_krw=100_000)
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=200_000)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert result.trades == ()
+
+    def test_cash_고갈_이후_매수_skip(self):
+        """누적 매수로 잔액 부족 → 일부 lot 만 체결."""
+        # starting=300_000, monthly=150_000, close=10_000(slippage=0)
+        # 1월: qty=15, cost=150_000 → cash=150_000
+        # 2월: qty=15, cost=150_000 → cash=0
+        # 3월: total_cost=150_000 > cash=0 → skip
+        cfg = self._cfg(
+            starting_capital_krw=300_000,
+            monthly_investment_krw=150_000,
+        )
+        bars = [
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 0), close=10_000),
+            _make_bar(_SYMBOL, _kst(_D_FEB, 9, 0), close=10_000),
+            _make_bar(_SYMBOL, _kst(_D_MAR, 9, 0), close=10_000),
+        ]
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_MAR)
+
+        assert len(result.trades) == 2  # 3월 skip
+
+    def test_DCA_ExitSignal_미생성(self):
+        """DCAStrategy 는 ExitSignal 절대 미생성 — hypothetical 청산은 endgame 처리."""
+        from stock_agent.strategy.dca import DCAConfig, DCAStrategy
+
+        strategy = DCAStrategy(DCAConfig(monthly_investment_krw=100_000))
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=10_000)
+        signals = strategy.on_bar(bar)
+
+        from stock_agent.strategy.base import ExitSignal
+
+        exit_signals = [s for s in signals if isinstance(s, ExitSignal)]
+        assert exit_signals == []
+
+
+# ===========================================================================
+# E. compute_dca_baseline — 메트릭 계산
+# ===========================================================================
+
+
+class TestComputeDCABaselineMetrics:
+    """가격 +50%·-30% 케이스와 표본 부족 sharpe=0 검증."""
+
+    def _cfg(self, **kw) -> DCABaselineConfig:
+        defaults: dict[str, Any] = dict(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+            target_symbol=_SYMBOL,
+            purchase_day=1,
+            slippage_rate=Decimal("0"),
+            commission_rate=Decimal("0"),
+            sell_tax_rate=Decimal("0"),
+        )
+        defaults.update(kw)
+        return DCABaselineConfig(**defaults)
+
+    def test_가격_상승_total_return_양수(self):
+        """entry 10_000 → exit 15_000(+50%) → total_return_pct > 0, net_pnl_krw > 0."""
+        cfg = self._cfg(monthly_investment_krw=100_000)
+        # purchase_day=1이므로 1월 첫 분봉에서 매수
+        # 이후 close=15_000 로 상승
+        bars = [
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 0), close=10_000),  # 매수
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 1), close=15_000),  # 동월 추가 bar
+        ]
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_JAN)
+
+        assert result.metrics.total_return_pct > 0
+        assert result.metrics.net_pnl_krw > 0
+
+    def test_가격_하락_total_return_음수(self):
+        """entry 10_000 → exit 7_000(-30%) → total_return_pct < 0."""
+        cfg = self._cfg(monthly_investment_krw=100_000)
+        bars = [
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 0), close=10_000),
+            _make_bar(_SYMBOL, _kst(_D_JAN, 9, 1), close=7_000),
+        ]
+        loader = InMemoryBarLoader(bars)
+
+        result = compute_dca_baseline(loader, cfg, _D_JAN, _D_JAN)
+
+        assert result.metrics.total_return_pct < 0
+        assert result.metrics.max_drawdown_pct <= 0
+
+    def test_단일_월_샤프_zero_또는_기본값(self):
+        """세션 1건 → daily_returns 표본 부족 → sharpe_ratio == 0."""
+        cfg = self._cfg()
+        bar = _make_bar(_SYMBOL, _kst(_D1, 9, 0), close=10_000)
+        loader = InMemoryBarLoader([bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        assert result.metrics.sharpe_ratio == Decimal("0")
+
+
+# ===========================================================================
+# F. compute_dca_baseline — loader 호출 인터랙션
+# ===========================================================================
+
+
+class TestComputeDCABaselineLoaderInteraction:
+    """loader.stream 이 target_symbol 단일 튜플로 정확히 호출되는지 검증."""
+
+    def _cfg(self) -> DCABaselineConfig:
+        return DCABaselineConfig(
+            starting_capital_krw=1_000_000,
+            monthly_investment_krw=100_000,
+            target_symbol=_SYMBOL,
+        )
+
+    def test_loader_stream_target_symbol만_요청(self):
+        """compute_dca_baseline 이 loader.stream(_,_,(target_symbol,)) 로 호출."""
+        cfg = self._cfg()
+        loader = InMemoryBarLoader([])
+
+        with patch.object(loader, "stream", wraps=loader.stream) as mock_stream:
+            compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        mock_stream.assert_called_once()
+        positional = mock_stream.call_args.args
+        # stream(start, end, symbols) — positional 3번째 인자가 (_SYMBOL,)
+        assert positional[2] == (_SYMBOL,)
+
+    def test_비타겟_심볼_bar_무시(self):
+        """loader 에 비타겟 bar 가 섞여도 stream 호출 시 target_symbol 만 요청."""
+        cfg = self._cfg()
+        other_bar = _make_bar("005930", _kst(_D1, 9, 0), close=70_000)
+        target_bar = _make_bar(_SYMBOL, _kst(_D1, 9, 1), close=10_000)
+        # InMemoryBarLoader 는 stream(symbols=(_SYMBOL,)) 호출 시 비타겟 자동 필터링
+        loader = InMemoryBarLoader([other_bar, target_bar])
+
+        result = compute_dca_baseline(loader, cfg, _D1, _D1)
+
+        # target_symbol 분봉 1건만 처리됨 (매수 1건)
+        assert len(result.trades) == 1

--- a/tests/test_daily_bar_loader.py
+++ b/tests/test_daily_bar_loader.py
@@ -1,0 +1,395 @@
+"""DailyBarLoader 공개 계약 단위 테스트 (RED 단계).
+
+대상 모듈: src/stock_agent/data/daily_bar_loader.py (미존재 — ImportError 로 FAIL 예상).
+외부 네트워크·DB·시계 접촉 0. HistoricalDataStore 는 in-memory fake double 사용.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from stock_agent.data import DailyBar, MinuteBar
+
+# ---------------------------------------------------------------------------
+# 지연 import — 모듈 미존재 시 ImportError/ModuleNotFoundError 로 RED
+# ---------------------------------------------------------------------------
+
+KST = timezone(timedelta(hours=9))
+
+
+def _import_loader():
+    from stock_agent.data.daily_bar_loader import DailyBarLoader
+
+    return DailyBarLoader
+
+
+def _import_kst():
+    from stock_agent.data.daily_bar_loader import KST as MODULE_KST
+
+    return MODULE_KST
+
+
+# ---------------------------------------------------------------------------
+# Fake doubles
+# ---------------------------------------------------------------------------
+
+
+def _make_daily_bar(
+    trade_date: date,
+    open_: str,
+    high: str,
+    low: str,
+    close: str,
+    volume: int,
+    *,
+    symbol: str = "069500",
+) -> DailyBar:
+    """테스트용 DailyBar 빌더 헬퍼."""
+    return DailyBar(
+        symbol=symbol,
+        trade_date=trade_date,
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=volume,
+    )
+
+
+def _make_expected_bar(
+    symbol: str,
+    trade_date: date,
+    open_: str,
+    high: str,
+    low: str,
+    close: str,
+    volume: int,
+) -> MinuteBar:
+    """기대값 MinuteBar 빌더 헬퍼."""
+    return MinuteBar(
+        symbol=symbol,
+        bar_time=datetime(
+            trade_date.year,
+            trade_date.month,
+            trade_date.day,
+            9,
+            0,
+            tzinfo=KST,
+        ),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=volume,
+    )
+
+
+class _FakeStore:
+    """HistoricalDataStore fake double.
+
+    fetch_daily_ohlcv 의 반환값을 심볼별로 미리 주입하고 호출 인자를 캡처한다.
+    """
+
+    def __init__(
+        self,
+        results: dict[str, list[DailyBar]] | None = None,
+        *,
+        raise_on_symbol: str | None = None,
+    ) -> None:
+        self._results: dict[str, list[DailyBar]] = results or {}
+        self._raise_on_symbol = raise_on_symbol
+        self.fetch_calls: list[tuple[str, date, date]] = []
+        self.close_count = 0
+
+    def fetch_daily_ohlcv(self, symbol: str, start: date, end: date) -> list[DailyBar]:
+        self.fetch_calls.append((symbol, start, end))
+        if self._raise_on_symbol and symbol == self._raise_on_symbol:
+            raise RuntimeError(f"store error for symbol={symbol}")
+        return self._results.get(symbol, [])
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+# ---------------------------------------------------------------------------
+# TestDailyBarLoaderStream — 정상 동작 6~8건
+# ---------------------------------------------------------------------------
+
+
+class TestDailyBarLoaderStream:
+    """stream() 정상 동작 검증."""
+
+    def test_단일심볼_단일영업일_1건_emit(self) -> None:
+        """단일 심볼, 단일 영업일: bar_time = datetime(d, 09:00, KST), OHLC·volume 일치."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        db = _make_daily_bar(d, "50000", "51000", "49000", "50500", 100_000)
+        store = _FakeStore({"069500": [db]})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d, d, ("069500",)))
+
+        assert len(bars) == 1
+        bar = bars[0]
+        assert bar.symbol == "069500"
+        assert bar.bar_time == datetime(2026, 4, 21, 9, 0, tzinfo=KST)
+        assert bar.open == Decimal("50000")
+        assert bar.high == Decimal("51000")
+        assert bar.low == Decimal("49000")
+        assert bar.close == Decimal("50500")
+        assert bar.volume == 100_000
+
+    def test_단일심볼_다중영업일_시간순_단조증가(self) -> None:
+        """단일 심볼 3 영업일: bar_time 이 단조증가 순서로 emit."""
+        DailyBarLoader = _import_loader()
+        d1 = date(2026, 4, 21)
+        d2 = date(2026, 4, 22)
+        d3 = date(2026, 4, 23)
+        bars_in = [
+            _make_daily_bar(d1, "100", "110", "90", "105", 1000),
+            _make_daily_bar(d2, "105", "115", "95", "110", 1100),
+            _make_daily_bar(d3, "110", "120", "100", "115", 1200),
+        ]
+        store = _FakeStore({"069500": bars_in})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d1, d3, ("069500",)))
+
+        assert len(bars) == 3
+        bar_times = [b.bar_time for b in bars]
+        assert bar_times == sorted(bar_times), "bar_time 단조증가 계약 위반"
+        assert bar_times[0].date() == d1
+        assert bar_times[1].date() == d2
+        assert bar_times[2].date() == d3
+
+    def test_다중심볼_동일날짜_심볼_알파벳_오름차순(self) -> None:
+        """2개 심볼 동일 날짜: (bar_time, symbol) 정렬 — 심볼 오름차순."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        db_a = _make_daily_bar(d, "200", "210", "190", "205", 2000, symbol="005930")
+        db_b = _make_daily_bar(d, "100", "110", "90", "105", 1000, symbol="069500")
+        store = _FakeStore({"005930": [db_a], "069500": [db_b]})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d, d, ("069500", "005930")))
+
+        assert len(bars) == 2
+        assert bars[0].symbol == "005930"
+        assert bars[1].symbol == "069500"
+        assert bars[0].bar_time == bars[1].bar_time  # 동일 날짜
+
+    def test_다중심볼_다중날짜_시간우선_심볼알파벳(self) -> None:
+        """2 심볼 × 2 날짜: 시간 우선 → 동일 시각은 심볼 알파벳 순."""
+        DailyBarLoader = _import_loader()
+        d1 = date(2026, 4, 21)
+        d2 = date(2026, 4, 22)
+        store = _FakeStore(
+            {
+                "005930": [
+                    _make_daily_bar(d1, "200", "210", "190", "205", 2000, symbol="005930"),
+                    _make_daily_bar(d2, "205", "215", "195", "210", 2100, symbol="005930"),
+                ],
+                "069500": [
+                    _make_daily_bar(d1, "100", "110", "90", "105", 1000, symbol="069500"),
+                    _make_daily_bar(d2, "105", "115", "95", "110", 1100, symbol="069500"),
+                ],
+            }
+        )
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d1, d2, ("005930", "069500")))
+
+        assert len(bars) == 4
+        # 날짜 d1 → d1 → d2 → d2, 동일 날짜 내 심볼 오름차순
+        assert bars[0].bar_time.date() == d1
+        assert bars[1].bar_time.date() == d1
+        assert bars[0].symbol < bars[1].symbol
+        assert bars[2].bar_time.date() == d2
+        assert bars[3].bar_time.date() == d2
+        assert bars[2].symbol < bars[3].symbol
+
+    def test_빈결과_빈_iterator(self) -> None:
+        """fetch_daily_ohlcv 가 빈 리스트 반환 시 stream 도 빈 Iterator."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        store = _FakeStore({"069500": []})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d, d, ("069500",)))
+
+        assert bars == []
+
+    def test_재호출_안전_동일결과(self) -> None:
+        """동일 인자로 stream 두 번 호출 → 각각 독립 소비 가능, 결과 동일."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        db = _make_daily_bar(d, "50000", "51000", "49000", "50500", 100_000)
+        # 두 번 호출에 대비해 결과 2번 반환
+        store = _FakeStore({"069500": [db]})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars1 = list(loader.stream(d, d, ("069500",)))
+        bars2 = list(loader.stream(d, d, ("069500",)))
+
+        assert len(bars1) == 1
+        assert len(bars2) == 1
+        assert bars1[0].bar_time == bars2[0].bar_time
+        assert bars1[0].symbol == bars2[0].symbol
+        assert bars1[0].close == bars2[0].close
+
+    def test_volume_그대로_전달(self) -> None:
+        """DailyBar.volume 이 MinuteBar.volume 으로 그대로 전달된다."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        expected_volume = 9_999_999
+        db = _make_daily_bar(d, "1000", "1100", "900", "1050", expected_volume)
+        store = _FakeStore({"069500": [db]})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d, d, ("069500",)))
+
+        assert bars[0].volume == expected_volume
+
+    def test_ohlc_decimal_정밀도_보존(self) -> None:
+        """DailyBar OHLC Decimal 정밀도가 MinuteBar 로 손실 없이 전달된다."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        open_ = Decimal("12345.67")
+        high = Decimal("12400.00")
+        low = Decimal("12300.50")
+        close = Decimal("12380.25")
+        db = DailyBar(
+            symbol="069500",
+            trade_date=d,
+            open=open_,
+            high=high,
+            low=low,
+            close=close,
+            volume=5000,
+        )
+        store = _FakeStore({"069500": [db]})
+
+        loader = DailyBarLoader(daily_store=store)
+        bars = list(loader.stream(d, d, ("069500",)))
+
+        assert bars[0].open == open_
+        assert bars[0].high == high
+        assert bars[0].low == low
+        assert bars[0].close == close
+
+
+# ---------------------------------------------------------------------------
+# TestDailyBarLoaderInputValidation — 가드 3건
+# ---------------------------------------------------------------------------
+
+
+class TestDailyBarLoaderInputValidation:
+    """stream() 입력 검증 — RuntimeError 가드."""
+
+    def test_start_gt_end_RuntimeError(self) -> None:
+        """start > end 시 RuntimeError, 메시지에 start/end 포함."""
+        DailyBarLoader = _import_loader()
+        store = _FakeStore()
+        loader = DailyBarLoader(daily_store=store)
+
+        start = date(2026, 4, 22)
+        end = date(2026, 4, 21)
+        with pytest.raises(RuntimeError, match=r"2026-04-22.*2026-04-21|2026-04-21.*2026-04-22"):
+            list(loader.stream(start, end, ("069500",)))
+
+    def test_symbols_빈튜플_RuntimeError(self) -> None:
+        """symbols=() 시 RuntimeError."""
+        DailyBarLoader = _import_loader()
+        store = _FakeStore()
+        loader = DailyBarLoader(daily_store=store)
+
+        d = date(2026, 4, 21)
+        with pytest.raises(RuntimeError):
+            list(loader.stream(d, d, ()))
+
+    def test_store_RuntimeError_전파(self) -> None:
+        """store.fetch_daily_ohlcv 가 RuntimeError 던질 때 DailyBarLoader 가 그대로 전파."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        store = _FakeStore(raise_on_symbol="069500")
+        loader = DailyBarLoader(daily_store=store)
+
+        with pytest.raises(RuntimeError, match="store error for symbol=069500"):
+            list(loader.stream(d, d, ("069500",)))
+
+
+# ---------------------------------------------------------------------------
+# TestDailyBarLoaderLifecycle — 3건
+# ---------------------------------------------------------------------------
+
+
+class TestDailyBarLoaderLifecycle:
+    """close() / 컨텍스트 매니저 수명주기 검증."""
+
+    def test_close_호출시_store_close_1회(self) -> None:
+        """close() 호출 시 daily_store.close() 정확히 1회 호출."""
+        DailyBarLoader = _import_loader()
+        store = _FakeStore()
+        loader = DailyBarLoader(daily_store=store)
+
+        loader.close()
+
+        assert store.close_count == 1
+
+    def test_컨텍스트_매니저_enter_자기자신_반환_exit_close(self) -> None:
+        """with DailyBarLoader(...) as loader: __enter__ 는 self 반환, __exit__ 시 close."""
+        DailyBarLoader = _import_loader()
+        store = _FakeStore()
+
+        with DailyBarLoader(daily_store=store) as loader:
+            assert isinstance(loader, DailyBarLoader)
+
+        assert store.close_count == 1
+
+    def test_close_멱등_두번호출_RuntimeError없음(self) -> None:
+        """close() 두 번 호출해도 RuntimeError 없음 (멱등)."""
+        DailyBarLoader = _import_loader()
+        store = _FakeStore()
+        loader = DailyBarLoader(daily_store=store)
+
+        loader.close()
+        loader.close()  # 두 번째 호출 — RuntimeError 없어야 함
+
+    # 멱등성 보장 여부 단언은 구현에 위임, 위 테스트는 "예외 없음" 만 검증
+
+
+# ---------------------------------------------------------------------------
+# TestDailyBarLoaderFetchDelegation — 2건
+# ---------------------------------------------------------------------------
+
+
+class TestDailyBarLoaderFetchDelegation:
+    """stream() 호출 시 store.fetch_daily_ohlcv 위임 검증."""
+
+    def test_단일심볼_fetch_1회_정확한_인자(self) -> None:
+        """stream(start, end, ("069500",)) → fetch_daily_ohlcv("069500", start, end) 1회."""
+        DailyBarLoader = _import_loader()
+        start = date(2026, 4, 21)
+        end = date(2026, 4, 25)
+        store = _FakeStore({"069500": []})
+        loader = DailyBarLoader(daily_store=store)
+
+        list(loader.stream(start, end, ("069500",)))
+
+        assert store.fetch_calls == [("069500", start, end)]
+
+    def test_두심볼_fetch_각1회(self) -> None:
+        """symbols=("069500", "005930") 시 fetch_daily_ohlcv 2회 (각 심볼 1회)."""
+        DailyBarLoader = _import_loader()
+        d = date(2026, 4, 21)
+        store = _FakeStore({"069500": [], "005930": []})
+        loader = DailyBarLoader(daily_store=store)
+
+        list(loader.stream(d, d, ("069500", "005930")))
+
+        called_symbols = {call[0] for call in store.fetch_calls}
+        assert called_symbols == {"069500", "005930"}
+        assert len(store.fetch_calls) == 2

--- a/tests/test_strategy_dca.py
+++ b/tests/test_strategy_dca.py
@@ -1,0 +1,387 @@
+"""DCAStrategy / DCAConfig 공개 계약 단위 테스트 (RED 단계).
+
+외부 네트워크·DB·시계 의존 없음 — 순수 로직 검증. 목킹 불필요.
+대상 모듈: src/stock_agent/strategy/dca.py (아직 없음 — ImportError 로 FAIL 예상).
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from stock_agent.data import MinuteBar
+from stock_agent.strategy import EntrySignal, ExitSignal
+from stock_agent.strategy.dca import DCAConfig, DCAStrategy
+
+# ---------------------------------------------------------------------------
+# 상수 / 헬퍼
+# ---------------------------------------------------------------------------
+
+KST = timezone(timedelta(hours=9))
+
+_SYMBOL = "069500"  # KODEX 200
+_DATE_JAN = date(2026, 1, 5)  # 1월 첫 영업일 (월요일)
+_DATE_FEB = date(2026, 2, 2)  # 2월 첫 영업일 (월요일)
+
+
+def _make_bar(
+    symbol: str,
+    bar_time: datetime,
+    close: int | str | Decimal,
+    *,
+    volume: int = 0,
+) -> MinuteBar:
+    """MinuteBar 생성 헬퍼. bar_time 은 KST aware datetime."""
+    c = Decimal(str(close))
+    return MinuteBar(
+        symbol=symbol,
+        bar_time=bar_time,
+        open=c,
+        high=c,
+        low=c,
+        close=c,
+        volume=volume,
+    )
+
+
+def _kst(d: date, h: int = 9, m: int = 0) -> datetime:
+    """KST aware datetime 헬퍼."""
+    return datetime(d.year, d.month, d.day, h, m, tzinfo=KST)
+
+
+# ---------------------------------------------------------------------------
+# 1. TestDCAConfig — DTO 가드
+# ---------------------------------------------------------------------------
+
+
+class TestDCAConfig:
+    def test_정상_생성_기본값(self):
+        """monthly_investment_krw 만 지정해도 기본값으로 생성."""
+        cfg = DCAConfig(monthly_investment_krw=100_000)
+        assert cfg.monthly_investment_krw == 100_000
+        assert cfg.target_symbol == "069500"
+        assert cfg.purchase_day == 1
+
+    def test_정상_생성_전체_명시(self):
+        """모든 필드 명시 — symbol="069500", purchase_day=5."""
+        cfg = DCAConfig(monthly_investment_krw=500_000, target_symbol="069500", purchase_day=5)
+        assert cfg.monthly_investment_krw == 500_000
+        assert cfg.target_symbol == "069500"
+        assert cfg.purchase_day == 5
+
+    def test_monthly_investment_krw_0_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=0)
+
+    def test_monthly_investment_krw_음수_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=-1)
+
+    def test_target_symbol_5자리_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=100_000, target_symbol="69500")
+
+    def test_target_symbol_영문혼합_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=100_000, target_symbol="ABC123")
+
+    def test_purchase_day_0_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=100_000, purchase_day=0)
+
+    def test_purchase_day_29_RuntimeError(self):
+        with pytest.raises(RuntimeError):
+            DCAConfig(monthly_investment_krw=100_000, purchase_day=29)
+
+    def test_frozen_필드_수정_FrozenInstanceError(self):
+        """frozen dataclass — 생성 후 필드 수정 불가."""
+        cfg = DCAConfig(monthly_investment_krw=100_000)
+        with pytest.raises(FrozenInstanceError):
+            cfg.monthly_investment_krw = 200_000  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. TestDCAStrategyMonthlyEntry — 핵심 진입 동작
+# ---------------------------------------------------------------------------
+
+
+class TestDCAStrategyMonthlyEntry:
+    def test_purchase_day1_첫분봉_EntrySignal(self):
+        """purchase_day=1: 1월 첫 분봉 수신 → EntrySignal."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        bar = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        signals = strategy.on_bar(bar)
+        assert len(signals) == 1
+        assert isinstance(signals[0], EntrySignal)
+        assert signals[0].symbol == _SYMBOL
+        assert signals[0].price == Decimal("55000")
+        assert signals[0].ts == _kst(_DATE_JAN)
+
+    def test_purchase_day1_같은달_두번째분봉_빈리스트(self):
+        """purchase_day=1: 동일 달 두 번째 분봉 → 이미 매수, 빈 리스트."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        bar1 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        bar2 = _make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 56_000)
+        strategy.on_bar(bar1)
+        signals = strategy.on_bar(bar2)
+        assert signals == []
+
+    def test_purchase_day1_다음달_첫분봉_EntrySignal(self):
+        """purchase_day=1: 2월 첫 분봉 → 월 카운터 리셋 후 EntrySignal."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        strategy.on_bar(_make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000))
+        bar_feb = _make_bar(_SYMBOL, _kst(_DATE_FEB), 56_000)
+        signals = strategy.on_bar(bar_feb)
+        assert len(signals) == 1
+        assert isinstance(signals[0], EntrySignal)
+        assert signals[0].ts == _kst(_DATE_FEB)
+
+    def test_purchase_day3_1_2분봉_빈리스트(self):
+        """purchase_day=3: 1·2번째 분봉 → 아직 도달 안 함, 빈 리스트."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=3)
+        strategy = DCAStrategy(cfg)
+        bar1 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        bar2 = _make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 55_100)
+        assert strategy.on_bar(bar1) == []
+        assert strategy.on_bar(bar2) == []
+
+    def test_purchase_day3_3번째분봉_EntrySignal(self):
+        """purchase_day=3: 3번째 분봉 도달 시 EntrySignal."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=3)
+        strategy = DCAStrategy(cfg)
+        bar1 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        bar2 = _make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 55_100)
+        bar3 = _make_bar(_SYMBOL, _kst(date(2026, 1, 7)), 55_200)
+        strategy.on_bar(bar1)
+        strategy.on_bar(bar2)
+        signals = strategy.on_bar(bar3)
+        assert len(signals) == 1
+        assert isinstance(signals[0], EntrySignal)
+
+    def test_purchase_day3_3번째후_추가분봉_빈리스트(self):
+        """purchase_day=3: 진입 후 4·5번째 분봉 → 당월 1회만, 빈 리스트."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=3)
+        strategy = DCAStrategy(cfg)
+        for i, d in enumerate(
+            [
+                _DATE_JAN,
+                date(2026, 1, 6),
+                date(2026, 1, 7),
+                date(2026, 1, 8),
+                date(2026, 1, 9),
+            ]
+        ):
+            signals = strategy.on_bar(_make_bar(_SYMBOL, _kst(d), 55_000 + i * 100))
+            if i < 2:
+                assert signals == [], f"bar {i + 1} should be empty"
+            elif i == 2:
+                assert len(signals) == 1
+            else:
+                assert signals == [], f"bar {i + 1} should be empty after entry"
+
+    def test_비target_symbol_bar_빈리스트(self):
+        """비타겟 심볼 bar → 무시, 빈 리스트 (카운터 미증가)."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        bar = _make_bar("005930", _kst(_DATE_JAN), 70_000)
+        signals = strategy.on_bar(bar)
+        assert signals == []
+
+    def test_다중심볼_혼재_스트림_target만_카운팅(self):
+        """비타겟·타겟 혼재 스트림 → 타겟 심볼만 카운팅."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=2)
+        strategy = DCAStrategy(cfg)
+        # 비타겟 먼저
+        strategy.on_bar(_make_bar("005930", _kst(_DATE_JAN), 70_000))
+        # 타겟 1번째 → 빈 리스트 (2번째에 진입)
+        s1 = strategy.on_bar(_make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000))
+        assert s1 == []
+        # 타겟 2번째 → EntrySignal
+        s2 = strategy.on_bar(_make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 55_100))
+        assert len(s2) == 1
+        assert isinstance(s2[0], EntrySignal)
+
+    def test_새해_12월_1월_경계_카운터리셋(self):
+        """12월 마지막 영업일 → 1월 첫 영업일 경계에서 카운터 리셋 후 EntrySignal."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        # 12월에 진입
+        strategy.on_bar(_make_bar(_SYMBOL, _kst(date(2025, 12, 1)), 54_000))
+        # 1월 첫 영업일 → 새 달이므로 카운터 리셋 후 EntrySignal
+        bar_jan = _make_bar(_SYMBOL, _kst(date(2026, 1, 2)), 55_000)
+        signals = strategy.on_bar(bar_jan)
+        assert len(signals) == 1
+        assert isinstance(signals[0], EntrySignal)
+
+    def test_EntrySignal_stop_take_price_Decimal0(self):
+        """DCA EntrySignal 의 stop_price·take_price 는 Decimal('0') — 손익절 미사용 마커."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        bar = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        signals = strategy.on_bar(bar)
+        assert len(signals) == 1
+        sig = signals[0]
+        assert isinstance(sig, EntrySignal)
+        assert sig.stop_price == Decimal("0")
+        assert sig.take_price == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# 3. TestDCAStrategyHolidaySkip — 영업일 캘린더 적용 (분봉 도달 순서 검증)
+# ---------------------------------------------------------------------------
+
+
+class TestDCAStrategyHolidaySkip:
+    def test_1월1일_휴일_첫분봉_1월3일_purchase_day1_EntrySignal(self):
+        """1월 1·2일 휴일 → 1월 3일이 첫 분봉. purchase_day=1 → 1월 3일 EntrySignal.
+
+        DCAStrategy 는 BusinessDayCalendar 의존 없이 '받은 분봉 순서'로 카운팅.
+        휴일은 분봉 미수신으로 자연스럽게 스킵.
+        """
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        # 1·2일 분봉 없음 (휴일) — 1월 3일이 첫 분봉
+        bar = _make_bar(_SYMBOL, _kst(date(2026, 1, 3)), 55_000)
+        signals = strategy.on_bar(bar)
+        assert len(signals) == 1
+        assert isinstance(signals[0], EntrySignal)
+        assert signals[0].ts.date() == date(2026, 1, 3)
+
+    def test_purchase_day4_분봉4건_4번째에서_EntrySignal(self):
+        """purchase_day=4 + 1월 분봉 4건(1·2·5·6일) → 4번째 분봉(1월 6일)에서 EntrySignal.
+
+        영업일 카운팅이 분봉 도달 순서로 처리됨을 확인 — 캘린더 의존 X.
+        1·2일 분봉 + 주말(3·4) 자연 스킵 + 5·6일 분봉 = 총 4 영업일 분봉.
+        """
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=4)
+        strategy = DCAStrategy(cfg)
+        jan_bars = [
+            _make_bar(_SYMBOL, _kst(date(2026, 1, 1)), 55_000),
+            _make_bar(_SYMBOL, _kst(date(2026, 1, 2)), 55_100),
+            _make_bar(_SYMBOL, _kst(date(2026, 1, 5)), 55_200),
+            _make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 55_300),
+        ]
+        results = [strategy.on_bar(b) for b in jan_bars]
+        assert results[0] == []
+        assert results[1] == []
+        assert results[2] == []
+        assert len(results[3]) == 1
+        assert isinstance(results[3][0], EntrySignal)
+        assert results[3][0].ts.date() == date(2026, 1, 6)
+
+
+# ---------------------------------------------------------------------------
+# 4. TestDCAStrategyNoExitSignal — 영구 보유 (청산 시그널 없음)
+# ---------------------------------------------------------------------------
+
+
+class TestDCAStrategyNoExitSignal:
+    def test_가격폭락_후_ExitSignal_미발생(self):
+        """매수 후 가격 -50% 폭락 분봉 → ExitSignal 미발생."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        strategy.on_bar(_make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000))
+        # 다음 달 -50% 폭락
+        bar_crash = _make_bar(_SYMBOL, _kst(_DATE_FEB), 27_500)
+        signals = strategy.on_bar(bar_crash)
+        exit_signals = [s for s in signals if isinstance(s, ExitSignal)]
+        assert exit_signals == []
+
+    def test_가격폭등_후_ExitSignal_미발생(self):
+        """매수 후 가격 +200% 폭등 분봉 → ExitSignal 미발생."""
+        cfg = DCAConfig(monthly_investment_krw=100_000, purchase_day=1)
+        strategy = DCAStrategy(cfg)
+        strategy.on_bar(_make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000))
+        bar_moon = _make_bar(_SYMBOL, _kst(_DATE_FEB), 165_000)
+        signals = strategy.on_bar(bar_moon)
+        exit_signals = [s for s in signals if isinstance(s, ExitSignal)]
+        assert exit_signals == []
+
+    def test_on_time_임의시각_빈리스트(self):
+        """on_time(임의 시각) → 빈 리스트 (force_close 없음)."""
+        strategy = DCAStrategy()
+        now = datetime(2026, 1, 5, 15, 0, tzinfo=KST)
+        signals = strategy.on_time(now)
+        assert signals == []
+
+
+# ---------------------------------------------------------------------------
+# 5. TestDCAStrategyInputValidation — 입력 가드
+# ---------------------------------------------------------------------------
+
+
+class TestDCAStrategyInputValidation:
+    def test_on_bar_symbol_5자리_RuntimeError(self):
+        """on_bar에서 symbol이 5자리 → RuntimeError."""
+        strategy = DCAStrategy()
+        bar = _make_bar("69500", _kst(_DATE_JAN), 55_000)
+        with pytest.raises(RuntimeError):
+            strategy.on_bar(bar)
+
+    def test_on_bar_naive_datetime_RuntimeError(self):
+        """on_bar에서 bar_time이 naive datetime → RuntimeError."""
+        strategy = DCAStrategy()
+        naive_dt = datetime(2026, 1, 5, 9, 0)  # tzinfo=None
+        bar = MinuteBar(
+            symbol=_SYMBOL,
+            bar_time=naive_dt,
+            open=Decimal("55000"),
+            high=Decimal("55000"),
+            low=Decimal("55000"),
+            close=Decimal("55000"),
+            volume=0,
+        )
+        with pytest.raises(RuntimeError):
+            strategy.on_bar(bar)
+
+    def test_on_time_naive_RuntimeError(self):
+        """on_time에서 now가 naive datetime → RuntimeError."""
+        strategy = DCAStrategy()
+        naive_now = datetime(2026, 1, 5, 15, 0)  # tzinfo=None
+        with pytest.raises(RuntimeError):
+            strategy.on_time(naive_now)
+
+    def test_on_bar_시간역행_RuntimeError(self):
+        """이전 bar_time보다 이른 bar_time → RuntimeError."""
+        strategy = DCAStrategy()
+        bar1 = _make_bar(_SYMBOL, _kst(date(2026, 1, 6)), 55_000)
+        bar2 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 54_000)  # 1월 5일 < 1월 6일
+        strategy.on_bar(bar1)
+        with pytest.raises(RuntimeError):
+            strategy.on_bar(bar2)
+
+    def test_on_bar_동일시각_허용(self):
+        """동일 bar_time 분봉 → RuntimeError 아님 (동등 허용)."""
+        strategy = DCAStrategy()
+        bar1 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_000)
+        bar2 = _make_bar(_SYMBOL, _kst(_DATE_JAN), 55_100)  # 동일 시각
+        strategy.on_bar(bar1)
+        # 동일 시각은 허용 — 예외 없이 처리
+        strategy.on_bar(bar2)  # RuntimeError 없으면 통과
+
+
+# ---------------------------------------------------------------------------
+# 6. TestDCAStrategyConfigExposure — config 프로퍼티 노출
+# ---------------------------------------------------------------------------
+
+
+class TestDCAStrategyConfigExposure:
+    def test_config_프로퍼티_주입된_DCAConfig_동일_반환(self):
+        """strategy.config 가 생성자에 주입한 DCAConfig 인스턴스와 동일."""
+        cfg = DCAConfig(monthly_investment_krw=200_000, purchase_day=3)
+        strategy = DCAStrategy(cfg)
+        assert strategy.config is cfg
+
+    def test_DCAStrategy_None_기본_DCAConfig_사용(self):
+        """DCAStrategy(None) → 기본 DCAConfig 사용 (에러 없음)."""
+        strategy = DCAStrategy(None)
+        cfg = strategy.config
+        assert isinstance(cfg, DCAConfig)
+        assert cfg.target_symbol == "069500"
+        assert cfg.purchase_day == 1


### PR DESCRIPTION
## Summary

- ADR-0019 Step F PR1 — F1 Buy & Hold DCA baseline 산출. ADR-0022 게이트 1·3 통과 (게이트 2 N/A 자기 자신).
- 결과: MDD **-12.92%** · Sharpe **2.2683** · 총수익률 **+51.50%** mark-to-market (1년치, 069500 KODEX 200, 자본 200만/월 10만, 243 영업일, 13 lots).
- 후속 PR (F2 Golden Cross 등) 의 게이트 2 (DCA 알파) 비교 베이스 산출.

## Code

| 모듈 | 경로 | 내용 |
|---|---|---|
| 전략 | `src/stock_agent/strategy/dca.py` | `DCAStrategy` + `DCAConfig`. `Strategy` Protocol 구현. 매월 N번째 분봉 `EntrySignal`, 청산 X, `on_time []`. |
| 일봉 어댑터 | `src/stock_agent/data/daily_bar_loader.py` | `DailyBarLoader` + `DailyBarSource` Protocol. `HistoricalDataStore` 일봉 → 09:00 KST `MinuteBar`. `BarLoader` 충족. |
| DCA 평가 | `src/stock_agent/backtest/dca.py` | `DCABaselineConfig` + `compute_dca_baseline`. 다중 lot 누적·mark-to-market·hypothetical 청산. `BacktestEngine` 우회 (단일 lot/force_close 가정 비호환). |
| CLI | `scripts/backtest.py` | `--strategy-type=dca` · `--loader=daily` · `--monthly-investment` 신규. ADR-0022 게이트 헬퍼 `_dca_verdict_label`. |

## Tests

- `tests/test_strategy_dca.py` 31 신규
- `tests/test_daily_bar_loader.py` 16 신규
- `tests/test_backtest_dca.py` 32 신규
- pytest **1670 → 1745 passed** (4 skipped, 회귀 0)
- ruff / black / pyright (`src scripts tests`) clean

## Docs

- 신규: `docs/runbooks/step_f_dca_baseline_2026-05-02.md`
- 갱신: root `CLAUDE.md` · `README.md` · `docs/step_f_strategy_pool_plan.md` · `src/stock_agent/{strategy,data,backtest}/CLAUDE.md` · `.claude/agents/markdown-writer.md`

## Test plan

- [x] pytest 전체 1745 passed
- [x] ruff / black / pyright clean
- [x] 백테스트 실행 확인 — `data/step_f_dca_baseline.md` PASS 라벨 검증
- [x] runbook 작성 + ADR-0022 게이트 판정 명시
- [ ] 운영자 검토 — runbook 결과 + 한계 (단일 종목 / 1년 표본 / 강세 구간) 인지

## 알려진 한계

- 단일 종목 / 1년 표본 — generalization 한계
- qty=1 양자화 영향 (월 10만 대비 ETF 단가 55k~86k)
- 2025-04~2026-04 KOSPI 200 강세 구간 — 음수 구간 보장 X

## 후속

PR2 (F2 Golden Cross) 진입 가능. 동일 데이터 소스·시작 자본·기간 유지 필수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)