### PR TITLE
feat(phase3): ADR-0025 PR3 — 15:00 force_close cron 비활성화 + Executor 분봉 stop_loss 가드

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,11 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
   - **C3 PASS (2026-05-03)**: `scripts/verify_069500_adjusted.py` + `data/c3_verify_069500.json`. `data/stock_agent.db` 캐시 458 행 = pykrx `adjusted=True` 458 행 close 완전 일치 (Stage 3 diff 0). ETF/KOSPI 200 (1028) 비율 점프 0건 (Stage 2). Google Finance · Wikipedia KOSPI 200 absolute level cross-check 정합 (Stage 4). pykrx 일봉 캐시는 수정주가 데이터로 확정 — PR1~PR5 절대 수익률은 데이터 보정 오류가 아닌 한국 KOSPI 200 강세장 macro 의 결과. 런북: `docs/runbooks/c3_069500_adjusted_plausibility_2026-05-03.md`.
   - **C4 통과 (2026-05-03)**: PR5 파라미터 sensitivity grid 96 조합 (5축: rsi_period 3×oversold 2×overbought 2×stop_loss 4×max_positions 2). DCA baseline +48.18% 대비 64/96 (66.67%) all_gates_pass. 현행 14/30/70/0.03/10 PASS, 1축 변동 인접 7/8 (87.5%). 게이트 1·3 100% PASS. Phase 3 진입 게이트 판정 PASS. 런북: `docs/runbooks/c4_rsi_mr_sensitivity_2026-05-03.md`.
 - **Phase 3 PR2 (2026-05-03)**: `main.py` 전략 wiring 교체 (`ORBStrategy` → `RSIMRStrategy`) + `RiskConfig` ADR-0025 확정값 명시 주입. `executor.py` — `strategy` 매개변수 타입 `ORBStrategy` → `Strategy` Protocol 확장, `restore_session` ORB 복원 루프를 `isinstance(strategy, ORBStrategy)` 가드로 감싸고 일봉 전략 EOD 자연 복원 warning 분기 추가.
-- **테스트 카운트**: pytest **2221 passed, 4 skipped** (PR2 기준).
+- **Phase 3 PR3 (2026-05-03)**: ADR-0025 결과 섹션 PR3 두 액션 완료.
+  - `main.py` `_install_jobs` — `isinstance(runtime.executor.strategy, RSIMRStrategy)` 가드 추가. RSI MR 모드면 `on_force_close` cron 미등록 + warning 로그("RSI MR 모드 — 15:00 force_close cron 미등록, ADR-0025"). ORB 등 일중 전략은 기존대로 등록.
+  - `executor.py` — `_OpenLot.stop_price: Decimal = Decimal("0")` 필드 추가(가드 비활성 마커). `_handle_entry` 가 `signal.stop_price` 를 보존. `_stop_loss_guard_signals(bar)` 헬퍼 신설 — `bar.low ≤ stop_price` 시 `ExitSignal(reason="stop_loss")` 반환. `step()` 분봉 루프에서 `strategy.on_bar` 호출 전 가드 체크 — 발동 시 strategy 호출 없이 ExitSignal 직접 처리. `Executor.strategy` 공개 프로퍼티 신설(main `_install_jobs` RSI MR 판정용).
+  - `restore_session` 및 `_handle_exit` fallback 은 `stop_price=Decimal("0")` 명시(가드 비활성 — 다음 EOD 일봉 자연 청산).
+- **테스트 카운트**: pytest **2231 passed, 4 skipped** (PR3 기준 — PR2 대비 +10: `TestInstallJobsRSIMRBranch` 4건 + `TestStepStopLossGuard` 6건).
 - **운영자 close 대기 Issue**: #51 (Phase 2 PASS 판정 FAIL → 복구 로드맵으로 대체) · #52 (`KisMinuteBarLoader` 파싱 실패 대응, 운영자 `scripts/debug_kis_minute.py` 실행 후 댓글) · #63 (공휴일 캘린더 가드, 백필 재실행으로 `date_mismatch` 0 확인 후 댓글) · #71 (장시간 hang 방지, 2026-04-24 백필 완주 확인 — 운영자 댓글만 잔여).
 
 상세한 Phase 별 산출물·결정·테스트 카운트 변화·Issue 대응 이력은 [docs/phase-history.md](./docs/phase-history.md) 참조.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ ORB 시절 기본값(종목당 20%, 동시 3종목, 손절 -1.5%, 익절 +3.0%, 
 
 **Phase 3 PR2 완료 (2026-05-03)**. `main.py` 전략 wiring `ORBStrategy` → `RSIMRStrategy` 교체 + `RiskConfig` ADR-0025 확정값 명시 주입. `executor.py` `strategy` 매개변수 타입을 `Strategy` Protocol 로 확장 + `restore_session` ORB/일봉 전략 분기 추가. ADR-0025 리스크 한도 운영 적용. pytest **2221 passed, 4 skipped**.
 
+**Phase 3 PR3 완료 (2026-05-03)**. `main.py` `_install_jobs` 에 RSI MR 모드 판정 가드 추가 — RSI MR 전략일 때 15:00 force_close cron 미등록(ADR-0025, 일봉 전략 강제청산 부적합). `executor.py` 분봉 stop_loss 가드 추가 — `_OpenLot.stop_price` 보존 + `bar.low ≤ stop_price` 도달 시 `strategy.on_bar` 없이 즉시 `ExitSignal(reason="stop_loss")` 처리. `Executor.strategy` 공개 프로퍼티 신설. pytest **2231 passed, 4 skipped** (+10).
+
 **Phase 3 착수 전제 통과** (2026-04-21). 실전 시세 전용 APP_KEY 3종 발급·IP 화이트리스트 등록·평일 장중 `healthcheck.py` 4종 그린(WebSocket 체결 수신 OK) 완료.
 
 **Phase 3 첫 산출물 — Executor (코드·테스트 레벨) 완료** (2026-04-21). `execution/` 패키지 신설 — `Executor` + Protocol 3종(`OrderSubmitter`/`BalanceProvider`/`BarSource`) + 어댑터 3종(`LiveOrderSubmitter`/`LiveBalanceProvider`/`DryRunOrderSubmitter`) + `StepReport`/`ReconcileReport` DTO. pytest **605건 green**.

--- a/docs/adr/0025-rsi-mr-operational-risk-limits.md
+++ b/docs/adr/0025-rsi-mr-operational-risk-limits.md
@@ -151,7 +151,7 @@ Phase 3 모의투자 무중단 운영 10영업일 후 다음을 회고하고 필
 ## 추적
 
 - 코드 (PR2 예정): `src/stock_agent/main.py` — `RiskConfig` 명시 주입, `RSIMRStrategy` import + 인스턴스 교체.
-- 코드 (PR3 예정): `src/stock_agent/main.py` — `15:00 force_close` cron 비활성화. `src/stock_agent/execution/executor.py` — 분봉 stop_loss 가드 추가. (`src/stock_agent/risk/manager.py` 변경 없음)
+- 코드 (PR3 완료, 2026-05-03): `src/stock_agent/main.py` — `15:00 force_close` cron 비활성화. `src/stock_agent/execution/executor.py` — 분봉 stop_loss 가드 추가. (`src/stock_agent/risk/manager.py` 변경 없음)
 - 관련 ADR: [ADR-0019](./0019-phase2-backtest-fail-remediation.md), [ADR-0022](./0022-step-f-gate-redefinition.md), [ADR-0023](./0023-rsi-mr-strategy-adoption-conditional.md), [ADR-0024](./0024-walk-forward-pass-threshold.md).
-- 도입 PR: TBD.
+- 도입 PR: PR3 (머지 완료, 2026-05-03).
 - 후속 ADR: ADR-0026 (10영업일 모의투자 회고 후 한도 갱신, 조건부).

--- a/plan.md
+++ b/plan.md
@@ -614,3 +614,17 @@ PR6 본 PR. 코드 변경 없음 — 종합 판정 런북 (`docs/runbooks/step_f
 [x] `src/stock_agent/execution/executor.py`: `strategy` 매개변수 타입 `ORBStrategy` → `Strategy` Protocol 로 확장. `restore_session` 의 ORB 상태 복원 루프(`restore_long_position`/`mark_session_closed`/`reset_session`)를 `isinstance(strategy, ORBStrategy)` 가드로 감싸고, else 분기에서 RSIMRStrategy 등 일봉 전략은 EOD 일봉 재흐름으로 자연 복원 가정 + warning 로그.
 
 pytest **2221 passed, 4 skipped** (PR2 기준).
+
+### Phase 3 PR3 — 15:00 force_close cron 비활성화 + Executor 분봉 stop_loss 가드 (2026-05-03, ADR-0025)
+
+[x] `src/stock_agent/main.py` (`_install_jobs`): `isinstance(runtime.executor.strategy, RSIMRStrategy)` 가드 추가. RSI MR 모드면 `on_force_close` cron 미등록 + warning 로그("RSI MR 모드 — 15:00 force_close cron 미등록, ADR-0025"). ORB 등 일중 전략은 기존대로 cron 등록. `RiskConfig` 변경 없음.
+
+[x] `src/stock_agent/execution/executor.py`:
+- `_OpenLot.stop_price: Decimal = Decimal("0")` 필드 추가. `0` 마커 = 가드 비활성(DCA 등 손절가 미사용 전략 + `restore_session` 복원 포지션).
+- `_handle_entry` — `_open_lots[symbol] = _OpenLot(entry_price=..., qty=..., stop_price=signal.stop_price)`. EntrySignal 의 stop_price 원본 보존.
+- `_handle_exit` fallback · `restore_session` — `stop_price=Decimal("0")` 명시(가드 비활성 — 다음 EOD 일봉 자연 청산).
+- `Executor.strategy` 공개 프로퍼티 신설(main `_install_jobs` RSI MR 판정용).
+- `_stop_loss_guard_signals(bar)` 헬퍼 신설. `lot.stop_price > 0` 이고 `bar.low <= lot.stop_price` 이면 `ExitSignal(reason="stop_loss", price=lot.stop_price, ts=bar.bar_time)` 반환.
+- `step()` 분봉 루프에 가드 호출 추가: bar 처리 시작 시 `_stop_loss_guard_signals(bar)` 호출 → 발동 시 `_process_signals` 처리 + `strategy.on_bar` 호출 skip.
+
+pytest **2231 passed, 4 skipped** (PR3 기준 — PR2 대비 +10: `TestInstallJobsRSIMRBranch` 4건 + `TestStepStopLossGuard` 6건).

--- a/src/stock_agent/execution/CLAUDE.md
+++ b/src/stock_agent/execution/CLAUDE.md
@@ -40,6 +40,14 @@ zero → skip + info 로그 + `return False` (RiskManager 미기록).
 `_handle_exit`: `status != "full"` → `ExecutorError` 승격 (운영자 개입 유도).
 `StepReport` 구조는 변경 없음 — `entry_events.qty` 가 실체결 수량으로 해석됨(계약 의미 명확화).
 
+**Phase 3 PR3 (ADR-0025) 완료(2026-05-03)에 따른 확장**:
+- `_OpenLot.stop_price: Decimal = Decimal("0")` 필드 추가. `0` = 가드 비활성 마커(DCA 등 손절가 미사용 전략 + `restore_session` 복원 포지션).
+- `_handle_entry` 가 `signal.stop_price` 를 `_OpenLot.stop_price` 에 보존. slippage 적용된 `entry_fill_price` 와 무관.
+- `_handle_exit` fallback · `restore_session` 은 `stop_price=Decimal("0")` 명시 (`OpenPositionInput` Protocol 에 `stop_price` 미포함 — 가드 비활성, 다음 EOD 일봉으로 자연 청산).
+- `_stop_loss_guard_signals(bar) -> list[Signal]` 헬퍼 신설. `lot.stop_price > 0` 이고 `bar.low <= lot.stop_price` 이면 `ExitSignal(reason="stop_loss", price=lot.stop_price, ts=bar.bar_time)` 반환.
+- `step()` 분봉 루프에 가드 호출 추가: 각 bar 처리 시 `_stop_loss_guard_signals(bar)` 먼저 호출 → 발동 시 `_process_signals` 처리 + `_last_processed_bar_time[symbol]` 갱신 후 `strategy.on_bar` 호출 skip.
+- `Executor.strategy` 공개 프로퍼티 신설 — `main.py` `_install_jobs` 의 RSI MR 판정용(`isinstance(executor.strategy, RSIMRStrategy)`).
+
 Phase 3 PASS 선언은 모의투자 환경에서 **연속 10영업일 무중단 + 0 unhandled
 error + 모든 주문이 SQLite 기록 + 텔레그램 알림 100% 수신** 후. 본 PR 은 그
 조건 중 단 하나도 자동으로 충족하지 않는다 — 이번 PR 의 산출은 단위 테스트로
@@ -130,6 +138,7 @@ step(now: datetime) -> StepReport          # 1 sweep
 force_close_all(now: datetime) -> StepReport
 reconcile() -> ReconcileReport
 is_halted (property)                       # _halt or risk_manager.is_halted
+strategy (property)                        # PR3 신설 — main._install_jobs RSI MR 판정용
 ```
 
 ### `ExecutorConfig` 필드
@@ -201,7 +210,9 @@ last_reconcile: ReconcileReport | None   # property, read-only
 ```text
 1. RiskManager.restore_session(session_date, starting_capital_krw,
        open_positions=..., entries_today=..., daily_realized_pnl_krw=...) 위임.
-2. open_positions 순회 → _open_lots[symbol] = _OpenLot(entry_price, qty).
+2. open_positions 순회 → _open_lots[symbol] = _OpenLot(entry_price, qty, stop_price=Decimal("0")).
+   # OpenPositionInput Protocol 에 stop_price 미포함 — 가드 비활성.
+   # 다음 EOD 일봉이 RSIMRStrategy.on_bar 에서 stop_loss 발동 시 자연 청산.
 3. isinstance(strategy, ORBStrategy) 가 True 인 경우 (ADR-0025 PR2):
    - open_positions 의 각 symbol 에 대해 strategy.restore_long_position(symbol, ...) 호출.
    - closed_symbols \ open_symbols 에 대해 strategy.mark_session_closed(symbol, session_date) 호출.
@@ -223,6 +234,13 @@ last_reconcile: ReconcileReport | None   # property, read-only
      bars = bar_source.get_minute_bars(symbol)
      for bar in bars:
          if bar.bar_time <= _last_processed_bar_time[symbol]: continue   # idempotent
+         # PR3 (ADR-0025): 분봉 stop_loss 가드 — bar.low ≤ lot.stop_price 시
+         # strategy.on_bar 호출 없이 ExitSignal(reason="stop_loss") 직접 처리.
+         guard_signals = _stop_loss_guard_signals(bar)
+         if guard_signals:
+             _process_signals(guard_signals)
+             _last_processed_bar_time[symbol] = bar.bar_time
+             continue
          signals = strategy.on_bar(bar)
          _process_signals(signals)
          _last_processed_bar_time[symbol] = bar.bar_time
@@ -246,7 +264,8 @@ last_reconcile: ReconcileReport | None   # property, read-only
 6. `entry_fill_price = buy_fill_price(signal.price, slippage_rate)` —
    `backtest.costs.buy_fill_price` 재사용.
 7. `risk_manager.record_entry(symbol, entry_fill_price, outcome.filled_qty, now)` +
-   `_open_lots[symbol] = _OpenLot(entry_fill_price, outcome.filled_qty)`. `status ==
+   `_open_lots[symbol] = _OpenLot(entry_price=entry_fill_price, qty=outcome.filled_qty, stop_price=signal.stop_price)`.
+   `signal.stop_price` 원본 보존(slippage 적용 전 전략 산출값). `status ==
    "partial"` 이면 warning 로그 (잔량 취소 완료, 체결분만 기록).
 
 ## ExitSignal 처리
@@ -383,3 +402,4 @@ generic `except Exception` 금지. `assert` 대신 명시적 예외. broker/stra
   와 동일).
 - **호가 단위 라운딩** — 현재 `Decimal` 원시 그대로. KRX 호가 단위 적용은
   Phase 5 재설계 범위.
+- **stop_price 영속화** — `OpenPositionInput`/`storage.OpenPositionRow` 에 `stop_price` 컬럼 추가는 별도 PR. 현재는 restore 후 가드 비활성(`Decimal("0")`), 다음 EOD 일봉으로 자연 청산. (ADR-0025 결과 섹션 + PR3 결정)

--- a/src/stock_agent/execution/executor.py
+++ b/src/stock_agent/execution/executor.py
@@ -392,10 +392,18 @@ class StepReport:
 
 @dataclass(frozen=True, slots=True)
 class _OpenLot:
-    """Executor 내부 진입 추적 — 청산 시 PnL 계산 입력으로 재사용."""
+    """Executor 내부 진입 추적 — 청산 시 PnL 계산 입력으로 재사용.
+
+    `stop_price` (PR3, ADR-0025) — EntrySignal.stop_price 원본값. 분봉 step
+    가드(`bar.low ≤ stop_price`) 가 활용. ``Decimal("0")`` 은 가드 비활성
+    마커 — 손절가 미사용 전략(DCA 등) 또는 `restore_session` 으로 복원된
+    포지션(OpenPositionInput 에 stop_price 미포함) 에서 사용. ``> 0`` 일
+    때만 가드 작동.
+    """
 
     entry_price: Decimal
     qty: int
+    stop_price: Decimal = Decimal("0")
 
 
 @dataclass(frozen=True, slots=True)
@@ -612,8 +620,16 @@ class Executor:
             )
 
         self._last_processed_bar_time.clear()
+        # PR3 (ADR-0025): OpenPositionInput Protocol 에 stop_price 가 없어
+        # 복원된 포지션은 가드 비활성(stop_price=Decimal("0")) 으로 시작.
+        # 다음 EOD 일봉이 RSIMRStrategy.on_bar 에서 stop_loss 발동 시 자연 청산.
         self._open_lots = {
-            p.symbol: _OpenLot(entry_price=p.entry_price, qty=p.qty) for p in positions
+            p.symbol: _OpenLot(
+                entry_price=p.entry_price,
+                qty=p.qty,
+                stop_price=Decimal("0"),
+            )
+            for p in positions
         }
         self._halt = False
         self._last_reconcile = None
@@ -653,6 +669,16 @@ class Executor:
             for bar in bars:
                 last_seen = self._last_processed_bar_time.get(symbol)
                 if last_seen is not None and bar.bar_time <= last_seen:
+                    continue
+                # PR3 (ADR-0025): 분봉 stop_loss 가드 — strategy 호출 없이
+                # Executor 가 독립적으로 처리. 활성 포지션의 stop_price 가 0
+                # 초과이고 bar.low 가 stop_price 이하이면 즉시 ExitSignal
+                # 직접 생성. 일봉 전략(RSIMRStrategy) 의 분봉 누적 오염 차단.
+                guard_signals = self._stop_loss_guard_signals(bar)
+                if guard_signals:
+                    processed_bars += 1
+                    self._last_processed_bar_time[symbol] = bar.bar_time
+                    orders_submitted += self._process_signals(guard_signals, now)
                     continue
                 signals = self._strategy.on_bar(bar)
                 processed_bars += 1
@@ -735,6 +761,15 @@ class Executor:
         return self._halt or self._risk_manager.is_halted
 
     @property
+    def strategy(self) -> Strategy:
+        """주입된 Strategy 인스턴스 (PR3, ADR-0025).
+
+        `main._install_jobs` 가 RSI MR 모드 판정(`isinstance(.., RSIMRStrategy)`) 에
+        사용. private `_strategy` 직접 참조 우회 경로를 제거하기 위한 공개 경계.
+        """
+        return self._strategy
+
+    @property
     def last_reconcile(self) -> ReconcileReport | None:
         """가장 최근 `reconcile()` 결과. 세션 시작 직후·호출 전에는 None.
 
@@ -767,6 +802,35 @@ class Executor:
         return tuple(self._sweep_exit_events)
 
     # ---- 시그널 처리 ---------------------------------------------------
+
+    def _stop_loss_guard_signals(self, bar: MinuteBar) -> list[Signal]:
+        """분봉 stop_loss 가드 — `bar.low ≤ lot.stop_price` 시 ExitSignal 직접 생성.
+
+        PR3 (ADR-0025) — RSI MR 일봉 전략의 분봉 운영 보호. `RSIMRStrategy.on_bar`
+        가 일봉을 소비하는 구조라 분봉 레벨 stop_loss 는 Executor 가 독립적으로
+        처리한다 (Strategy 호출 없이). `lot.stop_price == Decimal("0")` 은 가드
+        비활성 마커 — DCA 등 손절가 미사용 전략, `restore_session` 으로 복원된
+        포지션은 가드 작동 안 함.
+
+        가드 발동 시 ExitSignal(reason="stop_loss", price=lot.stop_price) 1건을
+        반환. 상위 `step()` 루프가 `_process_signals` 로 처리해 시장가 매도 +
+        ExitEvent 발행. 동일 bar 에 대한 strategy.on_bar 호출은 skip.
+        """
+        lot = self._open_lots.get(bar.symbol)
+        if lot is None:
+            return []
+        if lot.stop_price <= 0:
+            return []
+        if bar.low > lot.stop_price:
+            return []
+        return [
+            ExitSignal(
+                symbol=bar.symbol,
+                price=lot.stop_price,
+                ts=bar.bar_time,
+                reason="stop_loss",
+            )
+        ]
 
     def _process_signals(self, signals: list[Signal], now: datetime) -> int:
         count = 0
@@ -829,7 +893,15 @@ class Executor:
         filled_qty = outcome.filled_qty
         entry_fill_price = buy_fill_price(signal.price, self._config.slippage_rate)
         self._risk_manager.record_entry(signal.symbol, entry_fill_price, filled_qty, now)
-        self._open_lots[signal.symbol] = _OpenLot(entry_price=entry_fill_price, qty=filled_qty)
+        # PR3 (ADR-0025): EntrySignal.stop_price 원본을 _OpenLot 에 보존 — 분봉
+        # step 가드(`bar.low ≤ stop_price`) 가 활용. RSIMRStrategy 는 `bar.close
+        # × (1 - stop_loss_pct)` 를 stop_price 로 실어 보내고, ORBStrategy 도
+        # 동일 산식. stop_price=Decimal("0") 마커는 가드 비활성(DCA 등).
+        self._open_lots[signal.symbol] = _OpenLot(
+            entry_price=entry_fill_price,
+            qty=filled_qty,
+            stop_price=signal.stop_price,
+        )
         if outcome.status == "partial":
             logger.warning(
                 "executor.entry.partial symbol={symbol} filled_qty={f} requested={q} "
@@ -886,7 +958,13 @@ class Executor:
                 price=risk_pos.entry_price,
                 qty=risk_pos.qty,
             )
-            lot = _OpenLot(entry_price=risk_pos.entry_price, qty=risk_pos.qty)
+            # fallback 경로 — stop_price 미지정(가드 비활성). 외부 record_entry
+            # 우회 케이스라 EntrySignal 컨텍스트가 없다.
+            lot = _OpenLot(
+                entry_price=risk_pos.entry_price,
+                qty=risk_pos.qty,
+                stop_price=Decimal("0"),
+            )
 
         ticket = self._with_backoff(
             lambda: self._order_submitter.submit_sell(signal.symbol, lot.qty)

--- a/src/stock_agent/main.py
+++ b/src/stock_agent/main.py
@@ -4,14 +4,16 @@ Phase 3 두 번째 산출물. 이 모듈은 **조립만** 한다 — 전략·리
 단독 동작 계약은 이미 잠겨 있다.
 
 스케줄 (plan.md Phase 3, ADR-0011) — `_install_jobs` 가 등록하는 cron 4종
+(RSI MR 모드는 3종 — `on_force_close` 미등록, ADR-0025 PR3)
     09:00 KST  → on_session_start      (RiskManager/Executor 세션 리셋)
     매분 00s  → on_step                (Executor.step, 9-14시 평일)
-    15:00 KST  → on_force_close         (Executor.force_close_all)
+    15:00 KST  → on_force_close         (Executor.force_close_all, ORB 등 일중 전략만)
     15:30 KST  → on_daily_report        (일일 요약 로그)
 
 ※ 전략은 `RSIMRStrategy` (ADR-0023 채택, ADR-0025 한도 적용). 일봉 RSI 평균회귀라
-  `on_step` 분봉 호출만으로는 백테스트와 의미 정합되지 않음 — EOD 트리거 + 분봉 fill 추적
-  하이브리드 운영은 PR3 (ADR-0025 결과 섹션 참조) 에서 도입.
+  `on_step` 분봉 호출은 strategy.on_bar 의 RSI 의미를 오염시킬 수 있음 — EOD 트리거 +
+  분봉 fill 추적 풀 하이브리드 운영은 후속 PR. PR3 (ADR-0025 결과 섹션) 는 두 가지만
+  처리: (1) 15:00 force_close cron 비활성화 (2) Executor 분봉 stop_loss 가드.
 
 범위 (이번 PR)
     - `main.py` + APScheduler wiring + 드라이런 CLI 플래그
@@ -361,11 +363,23 @@ def _install_jobs(
         trigger=CronTrigger(day_of_week="mon-fri", hour="9-14", minute="*", second=0, timezone=tz),
         name="on_step",
     )
-    scheduler.add_job(
-        _on_force_close(runtime, effective_clock),
-        trigger=CronTrigger(day_of_week="mon-fri", hour=15, minute=0, second=0, timezone=tz),
-        name="on_force_close",
-    )
+    # PR3 (ADR-0025): RSI MR 모드면 15:00 force_close cron 등록 skip.
+    # 일봉 평균회귀 전략 특성상 일중 강제청산이 부적합 — 청산 시점은 다음
+    # 영업일 시초가(RSI 회귀 청산) 또는 분봉 stop_loss 가드(Executor 책임)
+    # 가 자연 결정한다. RSIMRStrategy.on_time 이 항상 빈 리스트라 cron 호출
+    # 자체가 무해하지만, 의미적 정합성과 운영자 혼란 방지를 위해 등록 자체
+    # 를 생략한다. ORBStrategy 등 일중 전략은 기존대로 등록.
+    if isinstance(runtime.executor.strategy, RSIMRStrategy):
+        logger.warning(
+            "main.install_jobs: RSI MR 모드 — 15:00 force_close cron 미등록 "
+            "(일봉 평균회귀 전략 강제청산 부적합, ADR-0025)."
+        )
+    else:
+        scheduler.add_job(
+            _on_force_close(runtime, effective_clock),
+            trigger=CronTrigger(day_of_week="mon-fri", hour=15, minute=0, second=0, timezone=tz),
+            name="on_force_close",
+        )
     scheduler.add_job(
         _on_daily_report(runtime, effective_clock),
         trigger=CronTrigger(day_of_week="mon-fri", hour=15, minute=30, second=0, timezone=tz),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -5116,3 +5116,411 @@ class TestExecutorRestoreSessionAtomicity:
             logger.remove(sink_id)
 
         assert len(log_messages) >= 1, "logger.critical 이 최소 1회 방출되어야 한다"
+
+
+# ===========================================================================
+# PR3 — 분봉 step stop_loss 가드 (RED)
+#
+# 검증 목표:
+#   (A) _handle_entry 가 EntrySignal.stop_price 를 _OpenLot 에 보존한다.
+#   (B) step() 분봉 처리 중 bar.low ≤ lot.stop_price 이면 즉시 시장가 매도
+#       + ExitEvent(reason="stop_loss") 발행, strategy.on_bar 미호출.
+#   (C) bar.low > stop_price 이면 가드 미발동, strategy.on_bar 정상 호출.
+#   (D) 가드 발동 후 _open_lots 에서 심볼 제거 + RiskManager.record_exit 호출.
+#   (E) stop_price=0 이면 가드 비활성.
+#
+# GREEN 단계에서 강제되는 결정:
+#   - _OpenLot 에 stop_price: Decimal 필드 추가 (frozen=True slots=True 유지).
+#   - _handle_entry 에서 signal.stop_price 를 _OpenLot 에 저장.
+#   - step() 분봉 루프에서 bar 처리 전 가드 체크:
+#       if lot.stop_price > 0 and bar.low <= lot.stop_price:
+#           ExitSignal(symbol, price=lot.stop_price, reason="stop_loss") 직접 처리
+#           strategy.on_bar(bar) 호출 skip.
+#   - stop_price=0 이면 가드 비활성 (signal 마커 패턴, rsi_mr.py 의 take_price=0 차용).
+# ===========================================================================
+
+
+class TestStepStopLossGuard:
+    """분봉 step 에서 _OpenLot.stop_price 기반 즉시 손절 가드 검증 (PR3 RED)."""
+
+    # -----------------------------------------------------------------------
+    # (A) stop_price 보존
+    # -----------------------------------------------------------------------
+
+    def test_handle_entry_signal_stop_price_직접_주입_보존(
+        self,
+        strategy: ORBStrategy,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """EntrySignal(stop_price=Decimal("49350")) 진입 후 _OpenLot.stop_price 보존.
+
+        RSIMRStrategy.on_bar 경유 없이 MagicMock strategy 로 EntrySignal 을 직접
+        주입해 _OpenLot.stop_price 저장 계약만 검증한다.
+
+        GREEN 단계: _OpenLot 에 stop_price 필드 추가 후 _handle_entry 가 저장.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        stop_price_val = Decimal("49350")
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        # on_bar 가 EntrySignal 을 반환하도록 설정
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=stop_price_val,
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+
+        # 진입이 승인되었으면 _OpenLot.stop_price 가 보존되어야 한다
+        # GREEN 단계: _OpenLot(entry_price=..., qty=..., stop_price=Decimal("49350"))
+        assert _SYMBOL_A in exc._open_lots, "_open_lots 에 진입 기록이 없다"  # type: ignore[attr-defined]
+        lot = exc._open_lots[_SYMBOL_A]  # type: ignore[attr-defined]
+        assert lot.stop_price == stop_price_val, (  # type: ignore[attr-defined]
+            f"_OpenLot.stop_price={getattr(lot, 'stop_price', 'MISSING')} 는 "
+            f"{stop_price_val} 여야 한다"
+        )
+
+    # -----------------------------------------------------------------------
+    # (B) 가드 발동: bar.low ≤ stop_price → 즉시 시장가 매도
+    # -----------------------------------------------------------------------
+
+    def test_step_분봉_low가_stop_price_이하면_즉시_시장가_매도(
+        self,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """bar.low ≤ lot.stop_price 이면 strategy.on_bar 없이 즉시 submit_sell 호출.
+
+        GREEN 단계: step() 분봉 루프에서 가드 체크 → ExitSignal 직접 처리.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        stop_price_val = Decimal("49000")
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=stop_price_val,
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        # 1차 step: 진입
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+        assert len(risk_manager.active_positions) == 1, "진입 전제 조건 미충족"
+
+        # 2차 step: bar.low ≤ stop_price → 가드 발동
+        mock_strategy.on_bar.return_value = []  # 이제 EntrySignal 없음
+        guard_bar = _bar(
+            _SYMBOL_A,
+            9,
+            35,
+            close=48_500,
+            high=49_200,
+            low=int(stop_price_val) - 100,  # 48_900 < 49_000
+        )
+        fake_bar_source.set_bars(_SYMBOL_A, [guard_bar])
+        report = exc.step(_kst(9, 36))
+
+        # 가드 발동 → submit_sell 1회
+        assert len(fake_order_submitter.sell_calls) == 1, (
+            f"stop_loss 가드 발동 시 submit_sell 1회 기대, "
+            f"실제={len(fake_order_submitter.sell_calls)}"
+        )
+        # StepReport 에 ExitEvent(reason="stop_loss") 포함
+        assert len(report.exit_events) == 1, f"exit_events 1건 기대, 실제={len(report.exit_events)}"
+        assert report.exit_events[0].reason == "stop_loss", (
+            f"reason='stop_loss' 기대, 실제={report.exit_events[0].reason}"
+        )
+
+    def test_step_분봉_가드_발동시_strategy_on_bar_미호출(
+        self,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """stop_loss 가드 발동 심볼·bar 에서 strategy.on_bar 가 호출되지 않는다.
+
+        GREEN 단계: 가드 발동 시 strategy.on_bar(bar) 호출 skip.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        stop_price_val = Decimal("49000")
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=stop_price_val,
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        # 진입
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+        mock_strategy.on_bar.reset_mock()
+        mock_strategy.on_bar.return_value = []
+
+        # 가드 발동 bar
+        guard_bar = _bar(_SYMBOL_A, 9, 35, close=48_500, high=49_200, low=int(stop_price_val) - 100)
+        fake_bar_source.set_bars(_SYMBOL_A, [guard_bar])
+        exc.step(_kst(9, 36))
+
+        # strategy.on_bar 가 guard_bar 로 호출되면 안 된다
+        for call_args in mock_strategy.on_bar.call_args_list:
+            bar_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("bar")
+            assert bar_arg is not guard_bar, (
+                "stop_loss 가드 발동 bar 에서 strategy.on_bar 가 호출되면 안 된다"
+            )
+
+    # -----------------------------------------------------------------------
+    # (C) 가드 미발동: bar.low > stop_price → strategy.on_bar 정상 호출
+    # -----------------------------------------------------------------------
+
+    def test_step_분봉_low_가_stop_price_초과면_가드_미발동_strategy_정상_호출(
+        self,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """bar.low > stop_price 이면 가드 패스 + strategy.on_bar 정상 호출.
+
+        GREEN 단계: 가드 미발동 경로에서 기존 strategy.on_bar 루프 그대로.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        stop_price_val = Decimal("49000")
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=stop_price_val,
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        # 진입
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+        mock_strategy.on_bar.reset_mock()
+        mock_strategy.on_bar.return_value = []
+
+        # low > stop_price — 가드 미발동
+        safe_bar = _bar(
+            _SYMBOL_A,
+            9,
+            35,
+            close=50_200,
+            high=50_500,
+            low=int(stop_price_val) + 500,  # 49_500 > 49_000
+        )
+        fake_bar_source.set_bars(_SYMBOL_A, [safe_bar])
+        exc.step(_kst(9, 36))
+
+        # strategy.on_bar 가 safe_bar 로 호출되어야 한다
+        called_bars = [
+            (c.args[0] if c.args else c.kwargs.get("bar"))
+            for c in mock_strategy.on_bar.call_args_list
+        ]
+        assert safe_bar in called_bars, (
+            "가드 미발동 시 strategy.on_bar(safe_bar) 가 호출되어야 한다"
+        )
+        # submit_sell 미호출
+        assert len(fake_order_submitter.sell_calls) == 0, (
+            "가드 미발동 시 submit_sell 이 호출되면 안 된다"
+        )
+
+    # -----------------------------------------------------------------------
+    # (D) 가드 발동 후 _open_lots 제거 + record_exit 호출
+    # -----------------------------------------------------------------------
+
+    def test_step_가드_발동_후_open_lots에서_제거(
+        self,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """stop_loss 가드 청산 후 _open_lots 에서 심볼 키 제거 + active_positions 비워짐.
+
+        GREEN 단계: _handle_exit 경로가 _open_lots.pop(symbol) + record_exit 를 수행.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        stop_price_val = Decimal("49000")
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=stop_price_val,
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        # 진입
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+        assert _SYMBOL_A in exc._open_lots, "진입 전제 조건: _open_lots 에 심볼 존재"  # type: ignore[attr-defined]
+
+        # 가드 발동
+        mock_strategy.on_bar.return_value = []
+        guard_bar = _bar(_SYMBOL_A, 9, 35, close=48_500, high=49_200, low=int(stop_price_val) - 100)
+        fake_bar_source.set_bars(_SYMBOL_A, [guard_bar])
+        exc.step(_kst(9, 36))
+
+        # _open_lots 에서 제거
+        assert _SYMBOL_A not in exc._open_lots, (  # type: ignore[attr-defined]
+            "가드 청산 후 _open_lots 에서 심볼이 제거되어야 한다"
+        )
+        # RiskManager.active_positions 비워짐
+        assert len(risk_manager.active_positions) == 0, (
+            "가드 청산 후 active_positions 가 비어있어야 한다"
+        )
+
+    # -----------------------------------------------------------------------
+    # (E) stop_price=0 이면 가드 비활성
+    # -----------------------------------------------------------------------
+
+    def test_handle_entry_stop_price_zero면_가드_비활성(
+        self,
+        risk_manager: RiskManager,
+        fake_order_submitter: FakeOrderSubmitter,
+        fake_balance_provider: FakeBalanceProvider,
+        fake_bar_source: FakeBarSource,
+    ) -> None:
+        """EntrySignal(stop_price=Decimal("0")) 진입 시 가드 비활성.
+
+        stop_price=0 은 가드 비활성 마커. bar.low 가 0 이하인 경우는
+        실무상 발생하지 않으므로 사실상 가드 작동 안 함.
+
+        GREEN 단계: lot.stop_price == 0 이면 가드 체크 skip.
+        """
+        from stock_agent.strategy.base import EntrySignal
+
+        mock_strategy = MagicMock(spec=ORBStrategy)
+        mock_strategy.on_bar.return_value = [
+            EntrySignal(
+                symbol=_SYMBOL_A,
+                price=Decimal("50000"),
+                ts=_kst(9, 30),
+                stop_price=Decimal("0"),  # 비활성 마커
+                take_price=Decimal("0"),
+            )
+        ]
+        mock_strategy.on_time.return_value = []
+
+        exc = _make_executor(
+            mock_strategy,  # type: ignore[arg-type]
+            risk_manager,
+            fake_order_submitter,
+            fake_balance_provider,
+            fake_bar_source,
+        )
+        exc.start_session(_DATE, _STARTING_CAPITAL)
+
+        # 진입
+        entry_bar = _bar(_SYMBOL_A, 9, 30, close=50_000)
+        fake_bar_source.set_bars(_SYMBOL_A, [entry_bar])
+        exc.step(_kst(9, 31))
+
+        # 진입 후 _open_lots.stop_price == 0
+        if _SYMBOL_A in exc._open_lots:  # type: ignore[attr-defined]
+            lot = exc._open_lots[_SYMBOL_A]  # type: ignore[attr-defined]
+            assert getattr(lot, "stop_price", Decimal("0")) == Decimal("0"), (  # type: ignore[attr-defined]
+                "stop_price=0 마커가 _OpenLot 에 보존되어야 한다"
+            )
+
+        mock_strategy.on_bar.reset_mock()
+        mock_strategy.on_bar.return_value = []
+
+        # bar.low 가 낮아도 stop_price=0 이면 가드 미발동
+        low_bar = _bar(_SYMBOL_A, 9, 35, close=40_000, high=45_000, low=1)
+        fake_bar_source.set_bars(_SYMBOL_A, [low_bar])
+        exc.step(_kst(9, 36))
+
+        # 가드 미발동 → submit_sell 없음
+        assert len(fake_order_submitter.sell_calls) == 0, (
+            "stop_price=0 마커 시 가드가 발동되면 안 된다"
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,7 +68,7 @@ from stock_agent.storage import (
     StorageError,
     TradingRecorder,
 )
-from stock_agent.strategy import ExitReason
+from stock_agent.strategy import ExitReason, ORBStrategy, StrategyConfig
 
 # ---------------------------------------------------------------------------
 # 공통 상수 / 헬퍼
@@ -2998,3 +2998,121 @@ class TestOnSessionStartRecorderNull:
         assert events_by_stage["session_start.recorder_null"].severity == "critical"
         assert events_by_stage["session_start"].error_class == "ConnectionError"
         assert events_by_stage["session_start"].severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# PR3 — _install_jobs RSI MR 분기: force_close cron 미등록 (RED)
+#
+# 검증 목표:
+#   1. runtime.executor.strategy 가 RSIMRStrategy 인스턴스이면
+#      on_force_close cron 을 등록하지 않는다 (add_job 3회).
+#   2. ORBStrategy 인스턴스이면 기존 4 cron 모두 등록 (회귀 방지).
+#   3. RSI MR 분기 진입 시 warning 로그("force_close cron" 포함 키워드)
+#      가 1회 이상 방출된다.
+#
+# GREEN 단계에서 강제되는 결정:
+#   - Executor.strategy 공개 프로퍼티 신설 (또는 Runtime.strategy 필드 추가).
+#   - _install_jobs 내부에서
+#     isinstance(runtime.executor.strategy, RSIMRStrategy) 분기.
+#   - skip 시 logger.warning 1회.
+# ---------------------------------------------------------------------------
+
+
+class TestInstallJobsRSIMRBranch:
+    """_install_jobs RSI MR 모드 force_close cron 미등록 검증 (PR3 RED)."""
+
+    @staticmethod
+    def _make_fake_executor_with_strategy(strategy: object) -> MagicMock:
+        """strategy 프로퍼티를 노출하는 Executor 더블.
+
+        GREEN 단계에서 Executor.strategy 공개 프로퍼티를 신설해야 한다.
+        """
+        fake_exc = MagicMock(spec=Executor)
+        # PropertyMock 없이 단순 attribute 로 주입.
+        # GREEN 단계에서 Executor 가 .strategy 프로퍼티를 노출하면
+        # spec=Executor 로 생성된 MagicMock 도 자동으로 attribute 를 통과시킨다.
+        fake_exc.strategy = strategy
+        return fake_exc
+
+    def test_install_jobs_rsimr_strategy면_on_force_close_cron_미등록(self) -> None:
+        """RSIMRStrategy 인스턴스인 경우 add_job 3회 (force_close 제외)."""
+        from apscheduler.schedulers.blocking import BlockingScheduler
+
+        from stock_agent.strategy.rsi_mr import RSIMRConfig, RSIMRStrategy
+
+        scheduler = MagicMock(spec=BlockingScheduler)
+        rsimr = RSIMRStrategy(RSIMRConfig(universe=("005930",)))
+        fake_exc = self._make_fake_executor_with_strategy(rsimr)
+        runtime = _make_runtime(scheduler=scheduler, executor=fake_exc)
+        args = _parse_args([])
+
+        _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
+
+        # GREEN 단계: force_close cron 미등록 → add_job 3회
+        assert scheduler.add_job.call_count == 3, (
+            f"RSIMRStrategy 모드에서 add_job 은 3회 기대, 실제={scheduler.add_job.call_count}"
+        )
+
+    def test_install_jobs_rsimr_strategy면_on_force_close_name_부재(self) -> None:
+        """등록된 job name 목록에 'on_force_close' 가 없어야 한다."""
+        from apscheduler.schedulers.blocking import BlockingScheduler
+
+        from stock_agent.strategy.rsi_mr import RSIMRConfig, RSIMRStrategy
+
+        scheduler = MagicMock(spec=BlockingScheduler)
+        rsimr = RSIMRStrategy(RSIMRConfig(universe=("005930",)))
+        fake_exc = self._make_fake_executor_with_strategy(rsimr)
+        runtime = _make_runtime(scheduler=scheduler, executor=fake_exc)
+        args = _parse_args([])
+
+        _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
+
+        registered_names = [c.kwargs.get("name") for c in scheduler.add_job.call_args_list]
+        assert "on_force_close" not in registered_names, (
+            f"RSIMRStrategy 모드에서 on_force_close 가 등록되면 안 된다. "
+            f"등록된 names={registered_names}"
+        )
+
+    def test_install_jobs_orb_strategy면_on_force_close_cron_등록(self) -> None:
+        """ORBStrategy 인스턴스이면 기존 4 cron 모두 등록 (회귀 방지)."""
+        from apscheduler.schedulers.blocking import BlockingScheduler
+
+        scheduler = MagicMock(spec=BlockingScheduler)
+        orb = ORBStrategy(StrategyConfig())
+        fake_exc = self._make_fake_executor_with_strategy(orb)
+        runtime = _make_runtime(scheduler=scheduler, executor=fake_exc)
+        args = _parse_args([])
+
+        _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
+
+        assert scheduler.add_job.call_count == 4, (
+            f"ORBStrategy 모드에서 add_job 은 4회 기대, 실제={scheduler.add_job.call_count}"
+        )
+        registered_names = [c.kwargs.get("name") for c in scheduler.add_job.call_args_list]
+        assert "on_force_close" in registered_names, (
+            f"ORBStrategy 모드에서 on_force_close 가 등록되어야 한다. "
+            f"등록된 names={registered_names}"
+        )
+
+    def test_install_jobs_rsimr_strategy_warning_로그(self, mocker: Any) -> None:
+        """RSI MR 분기 진입 시 'force_close' 키워드가 포함된 warning 로그 방출."""
+        from apscheduler.schedulers.blocking import BlockingScheduler
+
+        from stock_agent.strategy.rsi_mr import RSIMRConfig, RSIMRStrategy
+
+        mock_logger = mocker.patch("stock_agent.main.logger")
+        scheduler = MagicMock(spec=BlockingScheduler)
+        rsimr = RSIMRStrategy(RSIMRConfig(universe=("005930",)))
+        fake_exc = self._make_fake_executor_with_strategy(rsimr)
+        runtime = _make_runtime(scheduler=scheduler, executor=fake_exc)
+        args = _parse_args([])
+
+        _install_jobs(scheduler, runtime, args, clock=lambda: _kst(9, 0))
+
+        assert mock_logger.warning.call_count >= 1, (
+            "RSIMRStrategy 분기에서 logger.warning 이 1회 이상 방출되어야 한다"
+        )
+        all_args = str(mock_logger.warning.call_args_list)
+        assert "force_close" in all_args, (
+            f"warning 메시지에 'force_close' 키워드가 없다. 실제={all_args}"
+        )


### PR DESCRIPTION
## Summary

ADR-0025 결과 섹션 PR3 두 액션 구현. RSI MR 운영 모드에서 일중 강제청산 cron 을 비활성화하고, Executor 분봉 step 에 stop_loss 가드를 추가한다 — RSI MR 일봉 전략의 분봉 운영 보호.

- **main.py `_install_jobs`**: `isinstance(runtime.executor.strategy, RSIMRStrategy)` 가드 추가. RSI MR 모드면 `on_force_close` cron 등록 skip + warning 로그. ORB 등 일중 전략은 기존 4종 그대로.
- **executor.py 분봉 stop_loss 가드**: `_OpenLot.stop_price` 필드 추가 + `_handle_entry` 가 EntrySignal.stop_price 보존 + `step()` 분봉 루프에서 `bar.low ≤ stop_price` 시 strategy 호출 없이 ExitSignal 직접 처리. `Executor.strategy` 공개 프로퍼티 신설.

## 변경 상세

### main.py
- `_install_jobs` 의 `on_force_close` cron 등록을 RSI MR 모드일 때 skip:
  ```python
  if isinstance(runtime.executor.strategy, RSIMRStrategy):
      logger.warning("RSI MR 모드 — 15:00 force_close cron 미등록 ...")
  else:
      scheduler.add_job(_on_force_close(...), name="on_force_close")
  ```
- 모듈 docstring: cron 4종 → "RSI MR 모드는 3종 (`on_force_close` 미등록)" 명시.

### executor.py
- `_OpenLot.stop_price: Decimal = Decimal("0")` 필드 추가 (`Decimal("0")` = 가드 비활성 마커, DCA 등 손절가 미사용 전략 + restore 포지션).
- `_handle_entry` 가 `signal.stop_price` 원본 보존 (slippage 적용 entry_fill_price 와 무관).
- `restore_session` / `_handle_exit` fallback → `stop_price=Decimal("0")` 명시.
- `_stop_loss_guard_signals(bar)` 헬퍼 신설:
  - `lot.stop_price > 0` 이고 `bar.low <= lot.stop_price` 이면 `ExitSignal(reason="stop_loss", price=lot.stop_price, ts=bar.bar_time)` 1건 반환.
- `step()` 분봉 루프에 가드 호출 추가: 가드 발동 시 `_process_signals` 처리 + `_last_processed_bar_time[symbol]` 갱신 + `strategy.on_bar` 호출 skip (RSI MR 일봉 전략의 분봉 누적 오염 차단).
- `Executor.strategy` 공개 프로퍼티 신설 — main 의 RSI MR 판정용 (private `_strategy` 직접 참조 우회 경로 제거).

### 의도적 defer (별도 PR)
- `OpenPositionInput`/`storage.OpenPositionRow` 의 `stop_price` 컬럼 추가는 별도 PR. 현재는 restore 후 가드 비활성, 다음 EOD 일봉이 RSIMRStrategy.on_bar 에서 stop_loss 발동 시 자연 청산.
- EOD 트리거 + 분봉 fill 추적 풀 하이브리드 운영은 후속 PR (plan.md PR3 참조).

## Test plan

- [x] **TDD RED-first**: `unit-test-writer` 서브에이전트로 11 케이스 RED 작성 후 GREEN 구현.
- [x] **신규 테스트 10 케이스 (1 RED 단계 결함 케이스 삭제 후)**:
  - `tests/test_main.py::TestInstallJobsRSIMRBranch` (4): cron 등록 분기 검증 (RSI MR 미등록 / ORB 등록 / warning 로그 / job name 부재).
  - `tests/test_executor.py::TestStepStopLossGuard` (6): stop_price 보존 / 가드 발동 즉시 매도 / 가드 발동 시 strategy.on_bar 미호출 / 가드 미발동 정상 호출 / `_open_lots` 제거 / `stop_price=0` 비활성 마커.
- [x] **회귀**: pytest **2231 passed**, 4 skipped (PR2 기준 +10).
- [x] **정적 검사 4종**: `ruff check src scripts tests` + `ruff format --check src scripts tests` + `pyright src scripts tests` (0 errors) PASS.

## 문서 동기화

- `CLAUDE.md` — 현재 상태 섹션에 PR3 항목 추가, 테스트 카운트 갱신.
- `plan.md` — Phase 3 PR3 산출물 섹션 신규 추가.
- `README.md` — 현재 상태 PR3 완료 마킹.
- `src/stock_agent/execution/CLAUDE.md` — `_OpenLot.stop_price` / `_stop_loss_guard_signals` / `step()` 흐름 / `restore_session` 흐름 / `Executor.strategy` 프로퍼티 / `stop_price 영속화` defer 항목 추가.
- `docs/adr/0025-rsi-mr-operational-risk-limits.md` 추적 섹션 — PR3 완료 마킹 (결정·맥락·결과 4섹션은 보존).

## ADR-0025 결과 섹션 정합

| 액션 | 상태 |
|---|---|
| PR3 (main.py 15:00 force_close cron 비활성화) | 완료 |
| PR3 (Executor 분봉 step stop_loss 가드) | 완료 |
| 10영업일 모의투자 후 재검토 | 후속 (운영 데이터 누적 후) |

## 리스크 고지 (보존)

- 본 PR 의 가드 동작은 1년 백테스트 가정 (slip 0.1% / commission 0.015% / sell tax 0.18%) 기반.
- 운영 분봉 stop_loss 가드는 백테스트 (일봉 low 기준) 보다 빠른 손절 — 보수적 가정 (ADR-0025 결정 섹션).
- 모의투자 → 페이퍼 → 실전 단계 보존. 본 PR 단독으로 Phase 3 PASS 자동 충족 X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)