### PR TITLE
fix(storage): SqliteTradingRecorder cross-thread 안전성 보강 (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
 
 ## 현재 상태 (2026-05-04 기준)
 
-**한 줄 진행도**: Phase 1 PASS · **Phase 2 PASS (2026-05-03 공식 선언)** — ADR-0023 C1~C4 추가 검증 전원 통과. **Phase 3 진행 중** — `main.py` 모의투자 운영 착수. PR5 (ADR-0027): EOD 일봉 트리거 wiring 결손 해소 — 운영 첫날(2026-05-04) 결함 확인 후 즉시 수정.
+**한 줄 진행도**: Phase 1 PASS · **Phase 2 PASS (2026-05-03 공식 선언)** — ADR-0023 C1~C4 추가 검증 전원 통과. **Phase 3 진행 중** — `main.py` 모의투자 운영 착수. PR5 (ADR-0027): EOD 일봉 트리거 wiring 결손 해소 — 운영 첫날(2026-05-04) 결함 확인 후 즉시 수정. **Hotfix #113 (2026-05-04)**: `SqliteTradingRecorder` cross-thread 회귀 수정 — `check_same_thread=False` + `threading.RLock` 직렬화. APScheduler 워커 스레드 `record_daily_summary` silent fail 경로 차단.
 
 - **Phase 2 1차 백테스트 결과 (2026-04-24, 1년치 KIS 백필 + `--loader=kis`)**: MDD **-51.36%**, 총수익률 -50.05%, 샤프 -6.81, 승률 31.35%, 손익비 1.28, 기대값 ≈ -0.28R. Phase 2 PASS 기준 3.4 배 초과 미달.
 - **신규 Phase 2 PASS 게이트 (ADR-0019)**: (1) MDD > -15%, (2) 승률 × 손익비 > 1.0, (3) 연환산 샤프 > 0 — 세 조건 전부 충족 + walk-forward 통과 후에만 Phase 3 착수.
@@ -262,7 +262,7 @@ PR #18 에서 `ExitEvent.reason: str` 이 프로젝트 내 기존 `ExitReason = 
   - `main.py` — `Runtime` dataclass 에 `historical_store: HistoricalDataStore` 필드 추가 (총 9 → 10 필드). `_on_eod_signal(runtime, historical_store, *, clock) -> Callable[[], None]` 신규 콜백 — universe 일봉 fetch + `DailyBar→MinuteBar(09:00 KST)` 래핑 + `strategy.on_bar` 호출 + `enqueue_pending_signals` batched enqueue. `_install_jobs` RSI MR 모드 cron 3→4 (신규: `on_eod_signal` mon-fri 15:35 KST 등록). ORB 등 비-RSI MR 모드 cron 4종 그대로.
   - 운영 영향: 다음 영업일(2026-05-05 화)부터 EOD 15:35 KST 일봉 트리거 정상 작동. 진입/청산 시그널 → 다음 영업일 09:00 후 첫 step 에서 시초가 시장가 주문.
   - buffer 메모리 전용 (영속화 미포함 — 재기동 사이 손실 가능). 재기동 후 EOD cron 재발화 시 시그널 재구성으로 자연 복원 가능.
-- **테스트 카운트**: pytest **2266 passed, 4 skipped** (PR5 기준 — PR4 대비 +24: `TestPendingSignalsQueue` 13건 + `TestInstallJobsEodSignalRSIMR` 4건 + `TestOnEodSignalCallback` 6건 + 기존 카운트 갱신 1건).
+- **테스트 카운트**: pytest **2273 passed, 4 skipped** (Hotfix #113 기준 — PR5 대비 +7: `TestCrossThreadAccess` 7건 추가).
 - **운영자 close 대기 Issue**: #51 (Phase 2 PASS 판정 FAIL → 복구 로드맵으로 대체) · #52 (`KisMinuteBarLoader` 파싱 실패 대응, 운영자 `scripts/debug_kis_minute.py` 실행 후 댓글) · #63 (공휴일 캘린더 가드, 백필 재실행으로 `date_mismatch` 0 확인 후 댓글) · #71 (장시간 hang 방지, 2026-04-24 백필 완주 확인 — 운영자 댓글만 잔여).
 
 상세한 Phase 별 산출물·결정·테스트 카운트 변화·Issue 대응 이력은 [docs/phase-history.md](./docs/phase-history.md) 참조.

--- a/docs/adr/0013-sqlite-trading-ledger.md
+++ b/docs/adr/0013-sqlite-trading-ledger.md
@@ -71,6 +71,27 @@ Phase 3 PASS 기준(plan.md:198) 은 "모의투자 연속 10영업일 무중단 
 - `order_number` 를 PK 로 쓰면 같은 session 에서 KIS 가 재사용하는 사건(일반적으로는 없음) 에서 재INSERT 가 silent fail 로 흡수된다. 실무 운영에서는 문제되지 않지만 테스트에서는 `TestPrimaryKeyConflict` 로 동작을 명시 고정.
 - `daily_pnl` 의 `INSERT OR REPLACE` 는 "같은 날 재실행 시 마지막 값 유지" 계약 — 운영자가 장중 프로세스를 재시작했을 때 덮어쓰기 vs 다중 행 보존의 선택이었다. 현재 `session_date` 를 PK 로 고정했으므로 재시작 시 마지막 실행이 정본.
 
+## 후속 (2026-05-04, Issue #113)
+
+운영 첫날 (2026-05-04 15:30) `_on_daily_report` cron 발화 시 `sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 8276678848 and this is thread id 6176911360. consecutive=1` 1건 발생. silent fail + dedupe 경로 (결정 6) 가 운영 차단을 막았지만 daily_pnl 행이 기록되지 않아 ADR-0014 재기동 복원 경로가 무력화될 위험을 발견.
+
+근본 원인: `_open_connection` 이 `sqlite3.connect(...)` 호출 시 `check_same_thread` 인자를 지정하지 않아 기본값 True. `BlockingScheduler` (ADR-0011) 의 기본 executor 가 `ThreadPoolExecutor(max_workers=10)` 이라 cron 콜백이 워커 스레드에서 실행되는 반면 connection 자체는 `main._build_runtime` 메인 스레드에서 생성됨.
+
+후속 결정 (결정 6 silent fail 정책은 그대로 유지, 정책 번복 아님 — ADR 새로 작성 안 함):
+- `_open_connection` 의 `sqlite3.connect(...)` 양쪽 호출에 `check_same_thread=False` 추가.
+- `SqliteTradingRecorder.__init__` 에 `self._lock = threading.RLock()` 추가.
+- `_apply_pragmas`/`_init_schema`/`record_entry`/`record_exit`/`record_daily_summary`/`load_open_positions`/`load_daily_pnl`/`close` 의 `_conn.execute*` 진입을 `with self._lock:` 컨텍스트로 감쌈.
+- WAL + autocommit 이 reader/writer 동시성을 처리하지만 같은 Connection 객체를 두 스레드가 동시에 만지면 sqlite3 가 `OperationalError` 를 발생시키므로 직렬화 필수.
+
+회귀 테스트: `tests/test_storage_db.py::TestCrossThreadAccess` 7 케이스 신설 — 워커 스레드 record_*/load_* 정상 기록 + N=10 동시 record_entry 직렬화 누락 없음 + `_consecutive_failures` 카운터 0 검증.
+
+대안 비교 (Issue #113 본문):
+- B 안 (`max_workers=1` ThreadPoolExecutor): connection 생성도 같은 워커 스레드에서 해야 의미 있는데 `_build_runtime` 시점이 메인이라 단독으로는 해결 안 됨. 기각.
+- B' 안 (`threading.local` per-thread connection): close 시 모든 스레드 connection 추적 필요 + 테스트 fixture 영향 큼. YAGNI — 현재 운영은 직렬 실행이라 lock 으로 충분.
+- C 안 (queue executor): load_* 가 동기 반환이라 future/Event 신호 필요 → 복잡도 증가. 기각.
+
+A 안이 변경 비용 vs 안전성 비율 가장 좋다는 판단으로 채택.
+
 ## 추적
 
 - 코드: `src/stock_agent/storage/__init__.py`, `src/stock_agent/storage/db.py`, `src/stock_agent/execution/executor.py` (DTO 확장), `src/stock_agent/main.py` (Runtime·팩토리·콜백·close).

--- a/src/stock_agent/storage/CLAUDE.md
+++ b/src/stock_agent/storage/CLAUDE.md
@@ -20,6 +20,7 @@ stock-agent 의 영속화 경계 모듈. `Executor` 가 방출한 `EntryEvent`·
 **Phase 3 네 번째 산출물 — `storage/db.py` (코드·테스트 레벨) 완료** (2026-04-22).
 **Phase 3 다섯 번째 산출물 — 세션 재기동 복원 경로 (코드·테스트 레벨) 완료** (2026-04-22, Issue #33): `load_open_positions` · `load_daily_pnl` 2 메서드 + `OpenPositionRow` · `DailyPnlSnapshot` DTO 추가.
 **2026-04-22 후속 — `load_*` 행 단위 예외 격리 (Issue #40) 완료**: 쿼리 자체 실패는 빈 결과 + 카운터 +1, 개별 행 파싱 실패는 행 단위 skip + `logger.error`, 파싱 실패 1건 이상이면 메서드 카운터 +1 경로로 묶음.
+**2026-05-04 후속 — `SqliteTradingRecorder` cross-thread 안전성 보강 (Issue #113) 완료**: APScheduler 워커 스레드에서 `record_*`/`load_*` 를 호출했을 때 `sqlite3.ProgrammingError` (check_same_thread=True 기본값) 가 silent fail 로 흡수되던 경로를 차단. `_open_connection` 에 `check_same_thread=False` + `SqliteTradingRecorder._lock: threading.RLock` 으로 모든 `_conn.execute*` 호출을 직렬화. `TestCrossThreadAccess` 7 케이스 회귀 테스트 추가.
 
 의도적으로 미포함(defer):
 - 주간 회고 리포트 CLI (`scripts/weekly_report.py` 등) — MVP 는 SQL 직접 쿼리
@@ -256,12 +257,13 @@ CREATE TABLE IF NOT EXISTS daily_pnl (
 4. `close()` 이후 `record_*` 호출 → `logger.warning` 1회 + silent 반환. 카운터 불변.
 5. naive timestamp 입력 → `logger.warning` + 카운터 +1 + silent 반환 (DTO `__post_init__` 가 이미 차단하지만 defensive depth).
 6. **`load_*` 행 단위 격리 (Issue #40)** — 쿼리 자체 실패(`sqlite3.Error`·`ValueError`·`TypeError`) → 빈 결과 + `_on_failure` + 카운터 +1. 개별 행 파싱 실패(`Decimal` 변환·`datetime.fromisoformat`·`OpenPositionRow.__post_init__` RuntimeError 등) → 해당 행만 `logger.error` 로 skip, 나머지 행 정상 반환. 파싱 실패 1건 이상이면 `_on_failure` 를 1회 호출해 메서드별 카운터 +1 + dedupe 경보 경로를 탄다. 모든 행이 실패해도 크래시 없이 빈 결과(`()` / `DailyPnlSnapshot(session_date, 0, 0, ())`). `load_daily_pnl` 내부에서 `sold.add(symbol)` 은 `int(net_pnl)` 성공 이후에 실행해, 파싱 실패 시 해당 심볼이 `closed_symbols` 에 잘못 포함되지 않도록 한다.
+7. **cross-thread 안전성 (Issue #113)** — `_open_connection` 이 `check_same_thread=False` 로 cross-thread 호출을 허용하고, 모든 `_conn.execute*` 진입을 `_lock` (`threading.RLock`) 으로 직렬화. APScheduler `BlockingScheduler` 의 cron 콜백이 메인 스레드 connection 객체를 워커 스레드에서 호출해도 `sqlite3.ProgrammingError` 가 발생하지 않는다.
 
 ## 테스트 정책
 
 - 실제 파일 I/O: `":memory:"` (단위 테스트) 또는 `tmp_path` fixture (경로 테스트). 외부 의존 0.
 - KIS 네트워크·텔레그램·시계·실파일 절대 접촉 금지.
-- 관련 테스트 파일: `tests/test_storage_db.py`. 카테고리 — 공개 심볼 노출, `SqliteTradingRecorder` 생성·스키마·PRAGMA, `record_entry`/`record_exit`/`record_daily_summary` 정상·가드·DB 행 검증, silent fail + 연속 실패 dedupe, close 후 호출 내구성, `NullTradingRecorder` no-op, `StorageError` 계약, 컨텍스트 매니저, close 멱등. Issue #40 대응으로 `TestLoadOpenPositionsRowIsolation` · `TestLoadDailyPnlRowIsolation` 클래스 추가 (행 단위 파싱 실패 격리 검증).
+- 관련 테스트 파일: `tests/test_storage_db.py`. 카테고리 — 공개 심볼 노출, `SqliteTradingRecorder` 생성·스키마·PRAGMA, `record_entry`/`record_exit`/`record_daily_summary` 정상·가드·DB 행 검증, silent fail + 연속 실패 dedupe, close 후 호출 내구성, `NullTradingRecorder` no-op, `StorageError` 계약, 컨텍스트 매니저, close 멱등. Issue #40 대응으로 `TestLoadOpenPositionsRowIsolation` · `TestLoadDailyPnlRowIsolation` 클래스 추가 (행 단위 파싱 실패 격리 검증). Issue #113 대응으로 `TestCrossThreadAccess` 클래스 추가 (cross-thread 회귀 — 워커 스레드에서 record_*/load_* 정상 기록 + N=10 동시성 직렬화 검증).
 - SKIP 케이스 3건: naive timestamp 는 DTO `__post_init__` 가드가 선점하므로 `record_*` 진입 전 `RuntimeError` — SKIP 처리. 자세한 사유는 테스트 파일 내 주석 참조.
 - 테스트 파일 작성·수정은 반드시 `unit-test-writer` 서브에이전트 경유 (root CLAUDE.md 하드 규칙).
 
@@ -290,7 +292,7 @@ CREATE TABLE IF NOT EXISTS daily_pnl (
 - **PostgreSQL 전환** — plan.md "추후" 영역.
 - **부분체결 기록** — `Executor` 즉시 전량 체결 가정.
 - **스키마 마이그레이션 프레임워크** — `schema_version` 테이블 + 분기 훅만 준비. 실제 마이그레이션 로직은 v2 도입 시.
-- **멀티프로세스·스레드 safe** — 단일 프로세스 전용 (broker/strategy/risk/data/execution 와 동일).
+- **멀티프로세스 safe** — 단일 프로세스 전용 (broker/strategy/risk/data/execution 와 동일). 단, **단일 프로세스 내 멀티스레드 호출은 안전** — APScheduler `BlockingScheduler` 가 cron 콜백을 워커 스레드에서 실행하므로 `_open_connection` 은 `check_same_thread=False` + `_lock: threading.RLock` 직렬화로 cross-thread 호출을 받는다 (Issue #113, 2026-05-04).
 
 ## ADR
 

--- a/src/stock_agent/storage/db.py
+++ b/src/stock_agent/storage/db.py
@@ -64,8 +64,14 @@ PRAGMA (파일 기반만)
 - `foreign_keys = ON`
 
 스레드 모델
-- 단일 프로세스·단일 caller 전용 (broker/strategy/risk/data/execution 와
-  동일). 동시 호출 금지.
+- 단일 프로세스 전용 (broker/strategy/risk/data/execution 와 동일). 단,
+  APScheduler `BlockingScheduler` 가 cron 콜백을 워커 스레드에서 실행하므로
+  **단일 프로세스 내 멀티스레드 호출은 안전**해야 한다 (Issue #113, ADR-0013
+  결과 후속). `_open_connection` 은 `check_same_thread=False` 로 cross-thread
+  호출을 허용하고, 모든 `_conn.execute*` 진입을 `self._lock` (`threading.RLock`)
+  으로 직렬화한다. WAL + autocommit 이 reader/writer 동시성을 처리하지만 같은
+  Connection 객체를 두 스레드가 동시에 만지면 sqlite3 가 `OperationalError`
+  를 발생시키므로 직렬화가 필수.
 """
 
 from __future__ import annotations
@@ -74,6 +80,7 @@ import contextlib
 import json
 import re
 import sqlite3
+import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
@@ -336,6 +343,7 @@ class SqliteTradingRecorder:
         self._critical_emitted: dict[str, bool] = {op: False for op in _TRACKED_OPS}
         self._threshold = consecutive_failure_threshold
         self._is_memory = isinstance(db_path, str) and db_path == ":memory:"
+        self._lock = threading.RLock()
 
         self._conn = self._open_connection(db_path)
         try:
@@ -354,12 +362,18 @@ class SqliteTradingRecorder:
     def _open_connection(db_path: str | Path) -> sqlite3.Connection:
         """connect + 디렉토리·권한 가드.
 
+        `check_same_thread=False` 로 cross-thread 호출을 허용한다 (Issue #113):
+        APScheduler `BlockingScheduler` 의 cron 콜백이 워커 스레드에서 실행되는
+        반면 connection 자체는 메인 스레드(`main._build_runtime`) 에서 생성되기
+        때문. 동시성 안전은 `SqliteTradingRecorder._lock` (`threading.RLock`) 이
+        모든 `_conn.execute*` 호출을 직렬화해 보장한다.
+
         Raises:
             StorageError: 경로가 디렉토리이거나 connect 실패.
         """
         if isinstance(db_path, str) and db_path == ":memory:":
             try:
-                return sqlite3.connect(":memory:", isolation_level=None)
+                return sqlite3.connect(":memory:", isolation_level=None, check_same_thread=False)
             except sqlite3.Error as e:
                 raise StorageError(
                     f"SqliteTradingRecorder: sqlite3.connect(':memory:') 실패: {e}"
@@ -377,7 +391,7 @@ class SqliteTradingRecorder:
             with contextlib.suppress(OSError):
                 parent.mkdir(parents=True, exist_ok=True)
         try:
-            return sqlite3.connect(str(path), isolation_level=None)
+            return sqlite3.connect(str(path), isolation_level=None, check_same_thread=False)
         except sqlite3.Error as e:
             raise StorageError(
                 f"SqliteTradingRecorder: sqlite3.connect({path}) 실패: {e.__class__.__name__}: {e}"
@@ -385,10 +399,11 @@ class SqliteTradingRecorder:
 
     def _apply_pragmas(self) -> None:
         """WAL·NORMAL·foreign_keys. WAL 은 파일 기반에서만 적용."""
-        if not self._is_memory:
-            self._conn.execute("PRAGMA journal_mode = WAL")
-        self._conn.execute("PRAGMA synchronous = NORMAL")
-        self._conn.execute("PRAGMA foreign_keys = ON")
+        with self._lock:
+            if not self._is_memory:
+                self._conn.execute("PRAGMA journal_mode = WAL")
+            self._conn.execute("PRAGMA synchronous = NORMAL")
+            self._conn.execute("PRAGMA foreign_keys = ON")
 
     def _init_schema(self) -> None:
         """스키마 v1 을 IF NOT EXISTS 로 적용.
@@ -397,29 +412,30 @@ class SqliteTradingRecorder:
         동시 프로세스 경합 상황에서 `schema_version` 만 먼저 생성되고 나머지
         테이블은 미생성된 "부분 스키마" 상태가 남는 것을 막는다(리뷰 C3).
         """
-        cur = self._conn.cursor()
-        try:
-            cur.execute("BEGIN IMMEDIATE")
+        with self._lock:
+            cur = self._conn.cursor()
             try:
-                cur.execute(_CREATE_SCHEMA_VERSION_SQL)
-                cur.execute(_CREATE_ORDERS_SQL)
-                cur.execute(_CREATE_DAILY_PNL_SQL)
-                cur.execute(_CREATE_ORDERS_INDEX_SESSION)
-                cur.execute(_CREATE_ORDERS_INDEX_SYMBOL)
-                row = cur.execute("SELECT MAX(version) FROM schema_version").fetchone()
-                current = row[0] if row and row[0] is not None else 0
-                if current < _SCHEMA_VERSION:
-                    cur.execute(
-                        "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
-                        (_SCHEMA_VERSION,),
-                    )
-                cur.execute("COMMIT")
-            except Exception:
-                with contextlib.suppress(sqlite3.Error):
-                    cur.execute("ROLLBACK")
-                raise
-        finally:
-            cur.close()
+                cur.execute("BEGIN IMMEDIATE")
+                try:
+                    cur.execute(_CREATE_SCHEMA_VERSION_SQL)
+                    cur.execute(_CREATE_ORDERS_SQL)
+                    cur.execute(_CREATE_DAILY_PNL_SQL)
+                    cur.execute(_CREATE_ORDERS_INDEX_SESSION)
+                    cur.execute(_CREATE_ORDERS_INDEX_SYMBOL)
+                    row = cur.execute("SELECT MAX(version) FROM schema_version").fetchone()
+                    current = row[0] if row and row[0] is not None else 0
+                    if current < _SCHEMA_VERSION:
+                        cur.execute(
+                            "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
+                            (_SCHEMA_VERSION,),
+                        )
+                    cur.execute("COMMIT")
+                except Exception:
+                    with contextlib.suppress(sqlite3.Error):
+                        cur.execute("ROLLBACK")
+                    raise
+            finally:
+                cur.close()
 
     def _safe_close_conn(self) -> None:
         """예외 경로용 연결 닫기 — 실패 무시."""
@@ -457,21 +473,22 @@ class SqliteTradingRecorder:
             return
         session_date = event.timestamp.date().isoformat()
         try:
-            self._conn.execute(
-                "INSERT INTO orders "
-                "(order_number, session_date, symbol, side, qty, fill_price, "
-                " ref_price, exit_reason, net_pnl_krw, filled_at) "
-                "VALUES (?, ?, ?, 'buy', ?, ?, ?, NULL, NULL, ?)",
-                (
-                    event.order_number,
-                    session_date,
-                    event.symbol,
-                    int(event.qty),
-                    str(event.fill_price),
-                    str(event.ref_price),
-                    event.timestamp.isoformat(),
-                ),
-            )
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO orders "
+                    "(order_number, session_date, symbol, side, qty, fill_price, "
+                    " ref_price, exit_reason, net_pnl_krw, filled_at) "
+                    "VALUES (?, ?, ?, 'buy', ?, ?, ?, NULL, NULL, ?)",
+                    (
+                        event.order_number,
+                        session_date,
+                        event.symbol,
+                        int(event.qty),
+                        str(event.fill_price),
+                        str(event.ref_price),
+                        event.timestamp.isoformat(),
+                    ),
+                )
             self._on_success(_OP_RECORD_ENTRY)
         except Exception as e:  # noqa: BLE001 — I2: silent fail 계약 (매매 루프 보호)
             self._on_failure(_OP_RECORD_ENTRY, e)
@@ -499,23 +516,24 @@ class SqliteTradingRecorder:
             return
         session_date = event.timestamp.date().isoformat()
         try:
-            self._conn.execute(
-                "INSERT INTO orders "
-                "(order_number, session_date, symbol, side, qty, fill_price, "
-                " ref_price, exit_reason, net_pnl_krw, filled_at) "
-                "VALUES (?, ?, ?, 'sell', ?, ?, ?, ?, ?, ?)",
-                (
-                    event.order_number,
-                    session_date,
-                    event.symbol,
-                    int(event.qty),
-                    str(event.fill_price),
-                    str(event.fill_price),
-                    event.reason,
-                    int(event.net_pnl_krw),
-                    event.timestamp.isoformat(),
-                ),
-            )
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO orders "
+                    "(order_number, session_date, symbol, side, qty, fill_price, "
+                    " ref_price, exit_reason, net_pnl_krw, filled_at) "
+                    "VALUES (?, ?, ?, 'sell', ?, ?, ?, ?, ?, ?)",
+                    (
+                        event.order_number,
+                        session_date,
+                        event.symbol,
+                        int(event.qty),
+                        str(event.fill_price),
+                        str(event.fill_price),
+                        event.reason,
+                        int(event.net_pnl_krw),
+                        event.timestamp.isoformat(),
+                    ),
+                )
             self._on_success(_OP_RECORD_EXIT)
         except Exception as e:  # noqa: BLE001 — I2: silent fail 계약
             self._on_failure(_OP_RECORD_EXIT, e)
@@ -535,23 +553,24 @@ class SqliteTradingRecorder:
             return
         recorded_at = datetime.now(KST).isoformat()
         try:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO daily_pnl "
-                "(session_date, starting_capital_krw, realized_pnl_krw, "
-                " realized_pnl_pct, entries_today, halted, mismatch_symbols, "
-                " recorded_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    summary.session_date.isoformat(),
-                    summary.starting_capital_krw,
-                    int(summary.realized_pnl_krw),
-                    summary.realized_pnl_pct,
-                    int(summary.entries_today),
-                    1 if summary.halted else 0,
-                    json.dumps(list(summary.mismatch_symbols)),
-                    recorded_at,
-                ),
-            )
+            with self._lock:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO daily_pnl "
+                    "(session_date, starting_capital_krw, realized_pnl_krw, "
+                    " realized_pnl_pct, entries_today, halted, mismatch_symbols, "
+                    " recorded_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        summary.session_date.isoformat(),
+                        summary.starting_capital_krw,
+                        int(summary.realized_pnl_krw),
+                        summary.realized_pnl_pct,
+                        int(summary.entries_today),
+                        1 if summary.halted else 0,
+                        json.dumps(list(summary.mismatch_symbols)),
+                        recorded_at,
+                    ),
+                )
             self._on_success(_OP_RECORD_DAILY_SUMMARY)
         except Exception as e:  # noqa: BLE001 — I2: silent fail 계약
             self._on_failure(_OP_RECORD_DAILY_SUMMARY, e)
@@ -585,11 +604,12 @@ class SqliteTradingRecorder:
             )
             return ()
         try:
-            rows = self._conn.execute(
-                "SELECT side, symbol, qty, fill_price, order_number, filled_at "
-                "FROM orders WHERE session_date = ? ORDER BY filled_at ASC, rowid ASC",
-                (session_date.isoformat(),),
-            ).fetchall()
+            with self._lock:
+                rows = self._conn.execute(
+                    "SELECT side, symbol, qty, fill_price, order_number, filled_at "
+                    "FROM orders WHERE session_date = ? ORDER BY filled_at ASC, rowid ASC",
+                    (session_date.isoformat(),),
+                ).fetchall()
         except (sqlite3.Error, ValueError, TypeError) as e:
             self._on_failure(_OP_LOAD_OPEN_POSITIONS, e)
             return ()
@@ -656,10 +676,11 @@ class SqliteTradingRecorder:
             )
             return empty
         try:
-            rows = self._conn.execute(
-                "SELECT side, symbol, net_pnl_krw FROM orders WHERE session_date = ?",
-                (session_date.isoformat(),),
-            ).fetchall()
+            with self._lock:
+                rows = self._conn.execute(
+                    "SELECT side, symbol, net_pnl_krw FROM orders WHERE session_date = ?",
+                    (session_date.isoformat(),),
+                ).fetchall()
         except (sqlite3.Error, ValueError, TypeError) as e:
             self._on_failure(_OP_LOAD_DAILY_PNL, e)
             return empty
@@ -700,15 +721,16 @@ class SqliteTradingRecorder:
 
     def close(self) -> None:
         """멱등 close. 실패 경로에서도 호출 가능."""
-        if self._closed:
-            return
-        self._closed = True
-        try:
-            self._conn.close()
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                f"storage.close: connection close 실패 (무시): {e.__class__.__name__}: {e}"
-            )
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            try:
+                self._conn.close()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"storage.close: connection close 실패 (무시): {e.__class__.__name__}: {e}"
+                )
 
     def __enter__(self) -> SqliteTradingRecorder:
         return self

--- a/tests/test_storage_db.py
+++ b/tests/test_storage_db.py
@@ -1917,3 +1917,264 @@ class TestLoadDailyPnlRowIsolation:
         assert r._consecutive_failures["load_daily_pnl"] == 1
         mock_logger.warning.assert_called()
         mock_logger.critical.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #113 — cross-thread sqlite 접근 회귀 테스트 (RED 모드)
+#
+# 현재 _open_connection 이 check_same_thread 인자 없이 sqlite3.connect() 를
+# 호출 → 기본 True. APScheduler 워커 스레드에서 record_daily_summary 등을
+# 호출하면 sqlite3.ProgrammingError 로 silent fail → daily_pnl 미기록.
+#
+# 해결안 A: check_same_thread=False + threading.RLock 직렬화.
+# 아래 케이스는 해결안 A 구현 전까지 전부 FAIL 해야 한다.
+# ---------------------------------------------------------------------------
+import threading  # noqa: E402 — 파일 하단에 추가하는 import
+
+
+class TestCrossThreadAccess:
+    """Issue #113 — SqliteTradingRecorder 의 cross-thread sqlite 접근 회귀 테스트.
+
+    현재 구현(check_same_thread=True)에서 워커 스레드 호출은
+    sqlite3.ProgrammingError → silent fail → _consecutive_failures 카운터 +1.
+    해결안 A(check_same_thread=False + RLock) 적용 후 전원 GREEN 전환이 목표.
+    """
+
+    # ------------------------------------------------------------------
+    # 케이스 1: record_entry 워커 스레드 정상 기록
+    # ------------------------------------------------------------------
+
+    def test_record_entry_from_worker_thread_succeeds(self, tmp_path: Path) -> None:
+        """메인 스레드에서 생성한 recorder 를 워커 스레드에서 record_entry 호출.
+
+        join 후 orders 테이블에 1행이 기록되고 연속 실패 카운터는 0.
+        """
+        from stock_agent.storage.db import _OP_RECORD_ENTRY
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                recorder.record_entry(_make_entry_event())
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        conn = _get_conn(recorder)
+        row_count = conn.execute("SELECT COUNT(*) FROM orders").fetchone()[0]
+        assert row_count == 1, f"orders 행 수 기대 1, 실제 {row_count}"
+        # silent fail 없음 검증 — 카운터 0 이어야 정상 기록 의미
+        cnt = recorder._consecutive_failures[_OP_RECORD_ENTRY]
+        assert cnt == 0, f"record_entry 연속 실패 카운터={cnt} (0 기대)"
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 2: record_exit 워커 스레드 정상 기록
+    # ------------------------------------------------------------------
+
+    def test_record_exit_from_worker_thread_succeeds(self, tmp_path: Path) -> None:
+        """워커 스레드에서 record_exit 호출 → orders 테이블에 sell 행 1건 기록."""
+        from stock_agent.storage.db import _OP_RECORD_EXIT
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        # exit 기록 전에 entry 를 메인 스레드에서 먼저 삽입 (FK 없음 — 독립 삽입 가능)
+        recorder.record_entry(_make_entry_event(order_number="ORD-BUY-002"))
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                recorder.record_exit(_make_exit_event(order_number="ORD-SELL-002"))
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        conn = _get_conn(recorder)
+        sell_count = conn.execute("SELECT COUNT(*) FROM orders WHERE side='sell'").fetchone()[0]
+        assert sell_count == 1, f"sell 행 수 기대 1, 실제 {sell_count}"
+        cnt = recorder._consecutive_failures[_OP_RECORD_EXIT]
+        assert cnt == 0, f"record_exit 연속 실패 카운터={cnt} (0 기대)"
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 3: record_daily_summary 워커 스레드 — Issue #113 핵심 재현
+    # ------------------------------------------------------------------
+
+    def test_record_daily_summary_from_worker_thread_succeeds(self, tmp_path: Path) -> None:
+        """APScheduler cron 워커 스레드에서 record_daily_summary 호출.
+
+        daily_pnl 테이블에 1행이 기록되고 연속 실패 카운터는 0.
+        현재 check_same_thread=True 구현에서는 silent fail → 카운터 +1 로 FAIL.
+        """
+        from stock_agent.storage.db import _OP_RECORD_DAILY_SUMMARY
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                recorder.record_daily_summary(_make_daily_summary())
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        conn = _get_conn(recorder)
+        row_count = conn.execute("SELECT COUNT(*) FROM daily_pnl").fetchone()[0]
+        assert row_count == 1, f"daily_pnl 행 수 기대 1, 실제 {row_count}"
+        assert recorder._consecutive_failures[_OP_RECORD_DAILY_SUMMARY] == 0, (
+            "record_daily_summary 연속 실패 카운터="
+            f"{recorder._consecutive_failures[_OP_RECORD_DAILY_SUMMARY]} (0 기대)"
+        )
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 4: load_open_positions 워커 스레드
+    # ------------------------------------------------------------------
+
+    def test_load_open_positions_from_worker_thread_succeeds(self, tmp_path: Path) -> None:
+        """메인에서 record_entry 1건 → 워커에서 load_open_positions 호출 → 길이 1."""
+        from stock_agent.storage.db import _OP_LOAD_OPEN_POSITIONS
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        recorder.record_entry(_make_entry_event())
+
+        errors: list[Exception] = []
+        result: list[tuple] = []
+
+        def worker() -> None:
+            try:
+                positions = recorder.load_open_positions(_DATE)
+                result.append(positions)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        assert len(result) == 1, "워커가 반환값을 수집하지 못함"
+        assert len(result[0]) == 1, f"open positions 길이 기대 1, 실제 {len(result[0])}"
+        assert recorder._consecutive_failures[_OP_LOAD_OPEN_POSITIONS] == 0, (
+            "load_open_positions 연속 실패 카운터="
+            f"{recorder._consecutive_failures[_OP_LOAD_OPEN_POSITIONS]} (0 기대)"
+        )
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 5: load_daily_pnl 워커 스레드
+    # ------------------------------------------------------------------
+
+    def test_load_daily_pnl_from_worker_thread_succeeds(self, tmp_path: Path) -> None:
+        """메인에서 entry+exit 기록 → 워커에서 load_daily_pnl → entries_today=1, realized=8500."""
+        from stock_agent.storage.db import _OP_LOAD_DAILY_PNL
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        recorder.record_entry(_make_entry_event())
+        recorder.record_exit(_make_exit_event())
+
+        errors: list[Exception] = []
+        result: list = []
+
+        def worker() -> None:
+            try:
+                snap = recorder.load_daily_pnl(_DATE)
+                result.append(snap)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        assert len(result) == 1, "워커가 반환값을 수집하지 못함"
+        snap = result[0]
+        assert snap.entries_today == 1, f"entries_today 기대 1, 실제 {snap.entries_today}"
+        assert snap.realized_pnl_krw == 8_500, (
+            f"realized_pnl_krw 기대 8500, 실제 {snap.realized_pnl_krw}"
+        )
+        assert recorder._consecutive_failures[_OP_LOAD_DAILY_PNL] == 0, (
+            "load_daily_pnl 연속 실패 카운터="
+            f"{recorder._consecutive_failures[_OP_LOAD_DAILY_PNL]} (0 기대)"
+        )
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 6: N=10 동시 record_entry — lock 직렬화로 누락 없음
+    # ------------------------------------------------------------------
+
+    def test_concurrent_record_entry_serialized_no_loss(self, tmp_path: Path) -> None:
+        """10개 워커 스레드가 각각 다른 order_number 로 record_entry 동시 호출.
+
+        join 후 orders 테이블 행 수 == 10. lock 직렬화 회귀 방지.
+        """
+        from stock_agent.storage.db import _OP_RECORD_ENTRY
+
+        n = 10
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+        errors: list[Exception] = []
+
+        def worker(idx: int) -> None:
+            try:
+                recorder.record_entry(_make_entry_event(order_number=f"ORD-BUY-{idx:03d}"))
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"워커 스레드에서 예외 발생: {errors}"
+        conn = _get_conn(recorder)
+        row_count = conn.execute("SELECT COUNT(*) FROM orders").fetchone()[0]
+        assert row_count == n, f"orders 행 수 기대 {n}, 실제 {row_count} (누락 발생)"
+        cnt = recorder._consecutive_failures[_OP_RECORD_ENTRY]
+        assert cnt == 0, f"record_entry 연속 실패 카운터={cnt} (0 기대)"
+        recorder.close()
+
+    # ------------------------------------------------------------------
+    # 케이스 7: ProgrammingError 미발생 확인 — silent fail 카운터 직접 검증
+    # ------------------------------------------------------------------
+
+    def test_no_programming_error_raised_in_worker(self, tmp_path: Path) -> None:
+        """워커 스레드에서 record_daily_summary 호출 시 sqlite3.ProgrammingError 가
+        내부에서 발생해도 카운터 +1 로 관측된다.
+
+        현재 check_same_thread=True 구현에서는 ProgrammingError → silent fail →
+        _consecutive_failures[_OP_RECORD_DAILY_SUMMARY] >= 1 로 FAIL.
+        해결안 A 적용 후에는 카운터 == 0 으로 GREEN 전환.
+        """
+        from stock_agent.storage.db import _OP_RECORD_DAILY_SUMMARY
+
+        recorder = SqliteTradingRecorder(db_path=tmp_path / "trading.db")
+
+        def worker() -> None:
+            # record_daily_summary 는 silent fail — 외부에 raise 하지 않음.
+            recorder.record_daily_summary(_make_daily_summary())
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        # 핵심 RED 단언: cross-thread 오류 시 카운터가 1 이상이 된다.
+        # 해결안 A 적용 후 이 단언이 0 == 0 으로 GREEN 전환.
+        cnt = recorder._consecutive_failures[_OP_RECORD_DAILY_SUMMARY]
+        assert cnt == 0, (
+            f"sqlite3.ProgrammingError(cross-thread) 발생 → silent fail → "
+            f"카운터={cnt} (0 기대 — 해결안 A 미적용)"
+        )


### PR DESCRIPTION
## Summary

- 운영 첫날(2026-05-04 15:30) `_on_daily_report` cron 발화 시 `sqlite3.ProgrammingError` (`check_same_thread=True` 기본값) 가 silent fail 로 흡수돼 `daily_pnl` 행이 기록되지 않던 회귀 수정
- `_open_connection` 의 양쪽 `sqlite3.connect(...)` 에 `check_same_thread=False` 추가 + `SqliteTradingRecorder._lock: threading.RLock` 으로 모든 `_conn.execute*` 직렬화
- `TestCrossThreadAccess` 7 케이스 회귀 가드 신설 (워커 스레드 record_*/load_* + N=10 동시성)
- ADR-0013 결과 후속 절 + storage/CLAUDE.md + root CLAUDE.md 동기화

## 근본 원인

`SqliteTradingRecorder.__init__` 가 `sqlite3.connect(...)` 를 호출하는 시점은 `main._build_runtime` — 메인 스레드. APScheduler `BlockingScheduler` 의 기본 executor 가 `ThreadPoolExecutor(max_workers=10)` 이라 cron 콜백이 워커 스레드에서 실행됨. `sqlite3.Connection` 기본값 `check_same_thread=True` → cross-thread 호출 거부 → `record_*` / `load_*` 의 silent fail 카운터만 증가, daily_pnl 미기록 → ADR-0014 재기동 복원 무력화 위험.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `src/stock_agent/storage/db.py` | `_open_connection` `check_same_thread=False`. `__init__` `_lock = threading.RLock()`. `_apply_pragmas`/`_init_schema`/`record_entry`/`record_exit`/`record_daily_summary`/`load_open_positions`/`load_daily_pnl`/`close` `_conn.execute*` 를 `with self._lock:` 직렬화. 모듈 docstring 스레드 모델 갱신 |
| `tests/test_storage_db.py` | `TestCrossThreadAccess` 7 케이스 신설 |
| `docs/adr/0013-sqlite-trading-ledger.md` | 결과 섹션 뒤 `## 후속 (2026-05-04, Issue #113)` 추가. 결정·맥락·결과 본문 보존 |
| `src/stock_agent/storage/CLAUDE.md` | 현재 상태·실패 정책 (항목 7 추가)·테스트 정책·범위 제외 갱신 |
| `CLAUDE.md` | 한 줄 진행도에 Hotfix #113 추가, 테스트 카운트 2266→2273 |

## 채택안 — A (`check_same_thread=False` + 단일 RLock)

대안 비교 (Issue #113 본문):
- **B 안** `max_workers=1`: connection 생성도 워커 스레드여야 의미 있음. `_build_runtime` 메인 스레드라 단독 해결 안 됨. 기각
- **B' 안** `threading.local` per-thread connection: close 시 모든 스레드 connection 추적 필요. YAGNI
- **C 안** queue executor: load_* 동기 반환이라 future/Event 신호 필요 → 복잡도 증가. 기각

A 안 변경 비용 vs 안전성 비율 가장 좋음. silent fail 정책(ADR-0013 결정 6) 그대로 유지 → 새 ADR 미작성, 결과 후속 절만 추가.

## Test plan

- [x] `uv run pytest tests/test_storage_db.py::TestCrossThreadAccess -v` — 7/7 PASS
- [x] `uv run pytest tests/` — **2273 passed, 4 skipped**
- [x] `uv run ruff check src scripts tests` — PASS
- [x] `uv run ruff format --check src scripts tests` — PASS
- [x] `uv run pyright src scripts` — PASS

## 참고

- 관측 로그: `logs/stock-agent-2026-05-04.log:2026-05-04 15:30:00.053`
- 관련 ADR: ADR-0013 (storage/db 결정), ADR-0014 (재기동 복원)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)